### PR TITLE
Implemented entities for all Geo types currently supported by MongoDB

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/converters/DefaultConverters.java
+++ b/morphia/src/main/java/org/mongodb/morphia/converters/DefaultConverters.java
@@ -3,6 +3,8 @@ package org.mongodb.morphia.converters;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import org.mongodb.morphia.geo.GeometryConverter;
+import org.mongodb.morphia.geo.GeometryShapeConverter;
 import org.mongodb.morphia.logging.Logger;
 import org.mongodb.morphia.logging.MorphiaLoggerFactory;
 import org.mongodb.morphia.mapping.MappedField;
@@ -64,10 +66,19 @@ public class DefaultConverters {
         addConverter(new ObjectIdConverter());
         addConverter(new TimestampConverter());
 
+        // Converters for Geo entities
+        addConverter(new GeometryShapeConverter.PointConverter());
+        addConverter(new GeometryShapeConverter.LineStringConverter());
+        addConverter(new GeometryShapeConverter.MultiPointConverter());
+        addConverter(new GeometryShapeConverter.MultiLineStringConverter());
+        addConverter(new GeometryShapeConverter.PolygonConverter());
+        addConverter(new GeometryShapeConverter.MultiPolygonConverter());
+        addConverter(new GeometryConverter());
+
         //generic converter that will just pass things through.
         passthroughConverter = new PassthroughConverter();
         serializedConverter = new SerializedObjectConverter();
-        
+
     }
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeoJson.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeoJson.java
@@ -1,0 +1,132 @@
+package org.mongodb.morphia.geo;
+
+/**
+ * Factory class for creating GeoJSON types.  See 
+ * <a href="http://docs.mongodb.org/manual/applications/geospatial-indexes/#geojson-objects">the
+ * documentation</a> for all the types.
+ */
+public final class GeoJson {
+    private GeoJson() {
+    }
+
+    /**
+     * Create a new Point representing a <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a> point
+     * type.  For a safer way to create points with latitude and longitude coordinates without mixing up the order, see pointBuilder().
+     * <p/>
+     * Supported by server versions 2.4 and above.
+     *
+     * @param latitude  the point's latitude coordinate
+     * @param longitude the point's longitude coordinate
+     * @return a Point instance representing a single location point defined by the given latitude and longitude
+     * @see org.mongodb.morphia.geo.PointBuilder
+     */
+    public static Point point(final double latitude, final double longitude) {
+        return new Point(latitude, longitude);
+    }
+
+    /**
+     * Create a new LineString representing a <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * LineString type.  Supported by server versions 2.4 an above.
+     *
+     * @param points an ordered series of Points that make up the line
+     * @return a LineString instance representing a series of ordered points that make up a line
+     */
+    public static LineString lineString(final Point... points) {
+        return new LineString(points);
+    }
+
+    /**
+     * Create a new Polygon representing a <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * Polygon type. This helper method uses {@code org.mongodb.morphia.geo.GeoJson#polygon(LineString, LineString...)} to create the
+     * Polygon.  If you need to create Polygons with interior rings (holes), use that method.
+     * <p/>
+     * Supported by server versions 2.4 and above.
+     *
+     * @param points an ordered series of Points that make up the polygon.  The first and last points should be the same to close the
+     *               polygon
+     * @return a Polygon as defined by the points.
+     * @throws java.lang.IllegalArgumentException if the start and end points are not the same
+     * @see org.mongodb.morphia.geo.GeoJson#polygon(LineString, LineString...)
+     */
+    public static Polygon polygon(final Point... points) {
+        LineString exteriorBoundary = lineString(points);
+        ensurePolygonIsClosed(exteriorBoundary);
+        return new Polygon(exteriorBoundary);
+    }
+
+    /**
+     * Lets you create a Polygon representing a 
+     * <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * Polygon type. This method is especially useful for defining polygons with inner rings.
+     * <p/>
+     * Supported by server versions 2.4 and above.
+     *
+     * @param exteriorBoundary   a LineString that contains a series of Points that make up the polygon.  The first and last points should
+     *                           be the same to close the polygon
+     * @param interiorBoundaries optional varargs that let you define the boundaries for any holes inside the polygon
+     * @return a PolygonBuilder to be used to build up the required Polygon
+     * @throws java.lang.IllegalArgumentException if the start and end points are not the same
+     */
+    public static Polygon polygon(final LineString exteriorBoundary, final LineString... interiorBoundaries) {
+        ensurePolygonIsClosed(exteriorBoundary);
+        for (final LineString boundary : interiorBoundaries) {
+            ensurePolygonIsClosed(boundary);
+        }
+        return new Polygon(exteriorBoundary, interiorBoundaries);
+    }
+
+    /**
+     * Create a new MultiPoint representing a <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * MultiPoint type.  Supported by server versions 2.6 and above.
+     *
+     * @param points a set of points that make up the MultiPoint object
+     * @return a MultiPoint object containing all the given points
+     */
+    public static MultiPoint multiPoint(final Point... points) {
+        return new MultiPoint(points);
+    }
+
+    /**
+     * Create a new MultiLineString representing a <a href="http://docs.mongodb
+     * .org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * MultiLineString type.  Supported by server versions 2.6 and above.
+     *
+     * @param lines a set of lines that make up the MultiLineString object
+     * @return a MultiLineString object containing all the given lines
+     */
+    public static MultiLineString multiLineString(final LineString... lines) {
+        return new MultiLineString(lines);
+    }
+
+    /**
+     * Create a new MultiPolygon representing a <a href="http://docs.mongodb
+     * .org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * MultiPolygon type.  Supported by server versions 2.6 and above.
+     *
+     * @param polygons a series of polygons (which may contain inner rings)
+     * @return a MultiPolygon object containing all the given polygons
+     */
+    public static MultiPolygon multiPolygon(final Polygon... polygons) {
+        return new MultiPolygon(polygons);
+    }
+
+    /**
+     * Return a GeometryCollection that will let you create a GeometryCollection <a href="http://docs.mongodb
+     * .org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+     * GeometryCollection.  Supported by server version 2.6
+     *
+     * @param geometries a series of Geometry instances that will make up this GeometryCollection
+     * @return a GeometryCollection made up of all the geometries
+     */
+    public static GeometryCollection geometryCollection(final Geometry... geometries) {
+        return new GeometryCollection(geometries);
+    }
+
+    private static void ensurePolygonIsClosed(final LineString points) {
+        int size = points.getCoordinates().size();
+        if (size > 0 && !points.getCoordinates().get(0).equals(points.getCoordinates().get(size - 1))) {
+            throw new IllegalArgumentException("A polygon requires the starting point to be the same as the end to ensure a closed "
+                                               + "area");
+        }
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeoJsonType.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeoJsonType.java
@@ -1,0 +1,87 @@
+package org.mongodb.morphia.geo;
+
+import java.util.List;
+
+/**
+ * Enumerates all the GeoJson types that are currently supported by Morphia.
+ */
+@SuppressWarnings("unchecked") // can't know, or define generics for, the Lists in the factory
+public enum GeoJsonType implements GeometryFactory {
+    POINT("Point", Point.class) {
+        public Geometry createGeometry(final List coordinates) {
+            return new Point(coordinates);
+        }
+    },
+    LINE_STRING("LineString", LineString.class) {
+        public Geometry createGeometry(final List objects) {
+            return new LineString(objects);
+        }
+    },
+    POLYGON("Polygon", Polygon.class) {
+        public Geometry createGeometry(final List boundaries) {
+            return new Polygon(boundaries);
+        }
+    },
+    MULTI_POINT("MultiPoint", MultiPoint.class) {
+        public Geometry createGeometry(final List points) {
+            return new MultiPoint(points);
+        }
+    },
+    MULTI_LINE_STRING("MultiLineString", MultiLineString.class) {
+        public Geometry createGeometry(final List lineStrings) {
+            return new MultiLineString(lineStrings);
+        }
+    },
+    MULTI_POLYGON("MultiPolygon", MultiPolygon.class) {
+        public Geometry createGeometry(final List polygons) {
+            return new MultiPolygon(polygons);
+        }
+    };
+
+    private final String type;
+    private final Class<? extends Geometry> typeClass;
+
+    GeoJsonType(final String type, final Class<? extends Geometry> typeClass) {
+        this.type = type;
+        this.typeClass = typeClass;
+    }
+
+    /**
+     * Returns the value that needs to be stored with the GeoJson values in the database to declare which GeoJson type the coordinates
+     * represent. See <a href="http://docs.mongodb.org/manual/applications/geospatial-indexes/#geojson-objects">the documentation</a> for a
+     * list of the GeoJson objects supported by MongoDB.
+     *
+     * @return a String of the GeoJson type.
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Returns a concrete class that implements Geometry, the class that represents this GeoJsonType.
+     *
+     * @return the Geometry class for this GeoJsonType
+     */
+    public Class<? extends Geometry> getTypeClass() {
+        return typeClass;
+    }
+
+    /**
+     * Allows you to turn String values of types into the Enum that corresponds to this type.
+     *
+     * @param type a String, one of the values from 
+     *             <a href="http://docs.mongodb.org/manual/applications/geospatial-indexes/#geojson-objects">this
+     *             list</a> of supported types
+     * @return the GeoJsonType that corresponds to this type String
+     */
+    public static GeoJsonType fromString(final String type) {
+        if (type != null) {
+            for (final GeoJsonType geoJsonType : values()) {
+                if (type.equalsIgnoreCase(geoJsonType.getType())) {
+                    return geoJsonType;
+                }
+            }
+        }
+        throw new IllegalArgumentException(String.format("Cannot decode type into GeoJsonType. Type= '%s'", type));
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/Geometry.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/Geometry.java
@@ -1,0 +1,16 @@
+package org.mongodb.morphia.geo;
+
+import java.util.List;
+
+/**
+ * Interface to denote which entities are classes that will serialise into a MongoDB GeoJson object.
+ */
+public interface Geometry {
+    /**
+     * Returns a list of coordinates for this Geometry type.  For something like a Point, this will be a pair of lat/long coordinates, but
+     * for more complex types this will be a list of other Geometry objects.  Used for serialisation to MongoDB.
+     *
+     * @return a List containing either Geometry objects, or a pair of coordinates as doubles
+     */
+    List<?> getCoordinates();
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeometryCollection.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeometryCollection.java
@@ -1,0 +1,73 @@
+package org.mongodb.morphia.geo;
+
+import org.mongodb.morphia.annotations.Embedded;
+import org.mongodb.morphia.annotations.Entity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents a collection of mixed GeoJson objects as per the 
+ * <a href="http://geojson.org/geojson-spec.html#geometrycollection">GeoJSON specification</a>. Therefore this entity will never have its 
+ * own ID or store the its Class name.
+ * <p/>
+ * The factory for creating a MultiPoint is the {@code GeoJson.multiPoint} method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson
+ */
+@Embedded
+@Entity(noClassnameStored = true)
+public class GeometryCollection {
+    private final String type = "GeometryCollection";
+    private final List<Geometry> geometries;
+
+    @SuppressWarnings("UnusedDeclaration") // needed by morphia
+    private GeometryCollection() {
+        geometries = new ArrayList<Geometry>();
+    }
+
+    GeometryCollection(final List<Geometry> geometries) {
+        this.geometries = geometries;
+    }
+
+    GeometryCollection(final Geometry... geometries) {
+        this.geometries = Arrays.asList(geometries);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GeometryCollection that = (GeometryCollection) o;
+
+        if (!geometries.equals(that.geometries)) {
+            return false;
+        }
+        if (!type.equals(that.type)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + geometries.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GeometryCollection{"
+               + "type='" + type + '\''
+               + ", geometries=" + geometries
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeometryConverter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeometryConverter.java
@@ -1,0 +1,29 @@
+package org.mongodb.morphia.geo;
+
+import com.mongodb.DBObject;
+import org.mongodb.morphia.converters.SimpleValueConverter;
+import org.mongodb.morphia.converters.TypeConverter;
+import org.mongodb.morphia.mapping.MappedField;
+
+/**
+ * A Morphia TypeConverter that knows how to turn things that are labelled with the Geometry interface into the correct concrete class,
+ * based on the GeoJSON type.
+ * <p/>
+ * Only implements the decode method as the concrete classes can encode themselves without needing a converter. It's when they come out of
+ * the database that there's not enough information for Morphia to automatically create Geometry instances.
+ */
+public class GeometryConverter extends TypeConverter implements SimpleValueConverter {
+    /**
+     * Sets up this converter to work with things that implement the Geometry interface
+     */
+    public GeometryConverter() {
+        super(Geometry.class);
+    }
+
+    @Override
+    public Object decode(final Class<?> targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) {
+        DBObject dbObject = (DBObject) fromDBObject;
+        String type = (String) dbObject.get("type");
+        return getMapper().getConverters().decode(GeoJsonType.fromString(type).getTypeClass(), fromDBObject, optionalExtraInfo);
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeometryFactory.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeometryFactory.java
@@ -1,0 +1,7 @@
+package org.mongodb.morphia.geo;
+
+import java.util.List;
+
+interface GeometryFactory {
+    Geometry createGeometry(List<?> geometries);
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/GeometryShapeConverter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/GeometryShapeConverter.java
@@ -1,0 +1,145 @@
+package org.mongodb.morphia.geo;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.mongodb.morphia.converters.SimpleValueConverter;
+import org.mongodb.morphia.converters.TypeConverter;
+import org.mongodb.morphia.mapping.MappedField;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mongodb.morphia.geo.GeoJsonType.LINE_STRING;
+import static org.mongodb.morphia.geo.GeoJsonType.MULTI_LINE_STRING;
+import static org.mongodb.morphia.geo.GeoJsonType.MULTI_POINT;
+import static org.mongodb.morphia.geo.GeoJsonType.MULTI_POLYGON;
+import static org.mongodb.morphia.geo.GeoJsonType.POINT;
+import static org.mongodb.morphia.geo.GeoJsonType.POLYGON;
+
+/**
+ * Converter that understands most Geometry instances are effectively just lists of either other geometry objects or double coordinates.
+ * Recursively encodes and decodes Geometry objects, but needs to be instantiated with a List of GeometryFactory instances that represented
+ * the hierarchy of Geometries that make up the required Geometry object.
+ * <p/>
+ * Overridden by subclasses to define exact behaviour for specific Geometry concrete classes.
+ */
+public class GeometryShapeConverter extends TypeConverter implements SimpleValueConverter {
+    private final GeoJsonType geoJsonType;
+    private final List<GeometryFactory> factories;
+
+    GeometryShapeConverter(final GeoJsonType... geoJsonTypes) {
+        super(geoJsonTypes[0].getTypeClass());
+        geoJsonType = geoJsonTypes[0];
+        this.factories = Arrays.<GeometryFactory>asList(geoJsonTypes);
+    }
+
+    @Override
+    public Object encode(final Object value, final MappedField optionalExtraInfo) {
+        Object encodedObjects = encodeObjects(((Geometry) value).getCoordinates());
+        return new BasicDBObject("type", geoJsonType.getType())
+               .append("coordinates", encodedObjects);
+    }
+
+    private Object encodeObjects(final List value) {
+        List<Object> encodedObjects = new ArrayList<Object>();
+        for (final Object object : value) {
+            if (object instanceof Geometry) {
+                //iterate through the list of geometry objects recursively until you find the lowest-level
+                encodedObjects.add(encodeObjects(((Geometry) object).getCoordinates()));
+            } else {
+                encodedObjects.add(getMapper().getConverters().encode(object));
+            }
+        }
+        return encodedObjects;
+    }
+
+    @Override
+    public Object decode(final Class<?> targetClass, final Object fromDBObject, final MappedField optionalExtraInfo) {
+        return decodeObject(((DBObject) fromDBObject).get("coordinates"), factories);
+    }
+
+    @SuppressWarnings("unchecked") // always have unchecked casts when dealing with raw classes
+    private Object decodeObject(final Object fromDBObject, final List<GeometryFactory> geometryFactories) {
+        if (!geometryFactories.isEmpty()) {
+            // we're expecting a list that can be turned into a geometry using one of these factories
+            GeometryFactory factory = geometryFactories.get(0);
+            if (fromDBObject instanceof List) {
+                List<Object> decodedObjects = new ArrayList<Object>();
+                for (final Object objectThatNeedsDecoding : (List) fromDBObject) {
+                    decodedObjects.add(decodeObject(objectThatNeedsDecoding, geometryFactories.subList(1, geometryFactories.size())));
+                }
+                return factory.createGeometry(decodedObjects);
+            }
+        }
+        return getMapper().getConverters().encode(fromDBObject);
+    }
+
+    /**
+     * Extends and therefore configures GeometryShapeConverter to provide the specific configuration for converting MultiPolygon objects to
+     * and from <a href="http://geojson.org/geojson-spec.html#id7">MongoDB representations</a> of the GeoJson.
+     */
+    public static class MultiPolygonConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new MultiPolygonConverter.
+         */
+        public MultiPolygonConverter() {
+            super(MULTI_POLYGON, POLYGON, LINE_STRING, POINT);
+        }
+    }
+
+    public static class PolygonConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new PolygonConverter.  This extends and therefore configures GeometryShapeConverter to provide the specific
+         * configuration for converting Polygon objects to and from <a href="http://geojson.org/geojson-spec.html#id4">MongoDB
+         * representations</a> of the GeoJson.
+         */
+        public PolygonConverter() {
+            super(POLYGON, LINE_STRING, POINT);
+        }
+    }
+
+    public static class MultiLineStringConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new MultiLineStringConverter.  This extends and therefore configures GeometryShapeConverter to provide the specific
+         * configuration for converting MultiLineString objects to and from <a href="http://geojson.org/geojson-spec.html#id6">MongoDB
+         * representations</a> of the GeoJson.
+         */
+        public MultiLineStringConverter() {
+            super(MULTI_LINE_STRING, LINE_STRING, POINT);
+        }
+    }
+
+    public static class MultiPointConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new MultiPointConverter. This extends and therefore configures GeometryShapeConverter to provide the specific
+         * configuration for converting MultiPoint objects to and from <a href="http://geojson.org/geojson-spec.html#id5">MongoDB
+         * representations</a> of the GeoJson.
+         */
+        public MultiPointConverter() {
+            super(MULTI_POINT, POINT);
+        }
+    }
+
+    public static class LineStringConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new LineStringConverter. This extends and therefore configures GeometryShapeConverter to provide the specific
+         * configuration for converting LineString objects to and from <a href="http://geojson.org/geojson-spec.html#id3">MongoDB
+         * representations</a> of the GeoJson.
+         */
+        public LineStringConverter() {
+            super(LINE_STRING, POINT);
+        }
+    }
+
+    public static class PointConverter extends GeometryShapeConverter {
+        /**
+         * Creates a new PointConverter. This extends and therefore configures GeometryShapeConverter to provide the specific configuration
+         * for converting Point objects to and from <a href="http://geojson.org/geojson-spec.html#id3">MongoDB representations</a> of the
+         * GeoJson.
+         */
+        public PointConverter() {
+            super(POINT);
+        }
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/LineString.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/LineString.java
@@ -1,0 +1,66 @@
+package org.mongodb.morphia.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents a GeoJSON LineString type.  Will be persisted into the database according to 
+ * <a href="http://geojson.org/geojson-spec.html#id3">the specification</a>. 
+ * <p/>
+ * The factory for creating a LineString is the {@code GeoJson.lineString} method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson#lineString(Point...) 
+ */
+public class LineString implements Geometry {
+    private final List<Point> coordinates;
+
+    @SuppressWarnings("UnusedDeclaration") // used by Morphia
+    private LineString() {
+        coordinates = new ArrayList<Point>();
+    }
+
+    LineString(final Point... points) {
+        this.coordinates = Arrays.asList(points);
+    }
+
+    LineString(final List<Point> points) {
+        coordinates = points;
+    }
+
+    @Override
+    public List<Point> getCoordinates() {
+        return coordinates;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LineString that = (LineString) o;
+
+        if (!coordinates.equals(that.coordinates)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return coordinates.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "LineString{"
+               + "coordinates=" + coordinates
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/MultiLineString.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/MultiLineString.java
@@ -1,0 +1,66 @@
+package org.mongodb.morphia.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents a series of lines, which will saved into MongoDB as per the 
+ * <a href="http://geojson.org/geojson-spec.html#id6">GeoJSON specification</a>. 
+ * <p/>
+ * The factory for creating a MultiLineString is the {@code GeoJson.multiLineString} method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson#multiLineString(LineString...) 
+ */
+public class MultiLineString implements Geometry {
+    private final List<LineString> coordinates;
+
+    @SuppressWarnings("UnusedDeclaration") // needed for Morphia
+    private MultiLineString() {
+        this.coordinates = new ArrayList<LineString>();
+    }
+
+    MultiLineString(final LineString... lineStrings) {
+        coordinates = Arrays.asList(lineStrings);
+    }
+
+    MultiLineString(final List<LineString> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    @Override
+    public List<LineString> getCoordinates() {
+        return coordinates;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MultiLineString that = (MultiLineString) o;
+
+        if (!coordinates.equals(that.coordinates)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return coordinates.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "MultiLineString{"
+               + "coordinates=" + coordinates
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/MultiPoint.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/MultiPoint.java
@@ -1,0 +1,66 @@
+package org.mongodb.morphia.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents a series of points, which will saved into MongoDB as per the <a href="http://geojson.org/geojson-spec
+ * .html#id5">GeoJSON specification</a>. 
+ * <p/>
+ * The factory for creating a MultiPoint is the {@code GeoJson.multiPoint} method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson#multiPoint(Point...)
+ */
+public class MultiPoint implements Geometry {
+    private final List<Point> coordinates;
+
+    @SuppressWarnings("UnusedDeclaration") // used by Morphia
+    private MultiPoint() {
+        this.coordinates = new ArrayList<Point>();
+    }
+
+    MultiPoint(final Point... points) {
+        this.coordinates = Arrays.asList(points);
+    }
+
+    MultiPoint(final List<Point> coordinates) {
+        this.coordinates = coordinates;
+    }
+
+    @Override
+    public List<Point> getCoordinates() {
+        return coordinates;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MultiPoint that = (MultiPoint) o;
+
+        if (!coordinates.equals(that.coordinates)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return coordinates.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "MultiPoint{"
+               + "coordinates=" + coordinates
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/MultiPolygon.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/MultiPolygon.java
@@ -1,0 +1,66 @@
+package org.mongodb.morphia.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class represents a set of polygons, which will saved into MongoDB as per the 
+ * <a href="http://geojson.org/geojson-spec.html#id7">GeoJSON specification</a>. 
+ * <p/>
+ * The factory for creating a MultiPolygon is the {@code GeoJson.multiPolygon} method.
+ * 
+ * @see org.mongodb.morphia.geo.GeoJson#multiPolygon(Polygon...) 
+ */
+public class MultiPolygon implements Geometry {
+    private final List<Polygon> coordinates;
+
+    @SuppressWarnings("UnusedDeclaration") // used by Morphia
+    private MultiPolygon() {
+        coordinates = new ArrayList<Polygon>();
+    }
+
+    MultiPolygon(final Polygon... polygons) {
+        coordinates = Arrays.asList(polygons);
+    }
+
+    MultiPolygon(final List<Polygon> polygons) {
+        coordinates = polygons;
+    }
+
+    @Override
+    public List<Polygon> getCoordinates() {
+        return coordinates;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MultiPolygon that = (MultiPolygon) o;
+
+        if (!coordinates.equals(that.coordinates)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return coordinates.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "MultiPolygon{"
+               + "coordinates=" + coordinates
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/Point.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/Point.java
@@ -1,0 +1,102 @@
+package org.mongodb.morphia.geo;
+
+import org.mongodb.morphia.annotations.Embedded;
+import org.mongodb.morphia.annotations.Entity;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Represents a GeoJSON Point type.  Will be persisted into the database according to <a href="http://geojson.org/geojson-spec.html#id2">the
+ * specification</a>. Therefore because of this, this entity will never have its own ID or store the its Class name.
+ * <p/>
+ * The builder for creating a Point is the {@code GeoJson.pointBuilder} method, or the helper {@code GeoJson.point} factory method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson#point(double, double)
+ * @see GeoJson#pointBuilder()
+ */
+@Embedded
+@Entity(noClassnameStored = true)
+public class Point implements Geometry {
+    private final double latitude;
+    private final double longitude;
+
+    @SuppressWarnings("unused") //needed for Morphia serialisation
+    private Point() {
+        longitude = 0;
+        latitude = 0;
+    }
+
+    Point(final double latitude, final double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    Point(final List<Double> coordinates) {
+        this(coordinates.get(1), coordinates.get(0));
+    }
+
+    @Override
+    public List<Double> getCoordinates() {
+        return Arrays.asList(longitude, latitude);
+    }
+
+    /**
+     * Return the latitude of this point.
+     *
+     * @return the Point's latitude
+     */
+    public double getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * Return the longitude of this point.
+     *
+     * @return the Point's longitude
+     */
+    public double getLongitude() {
+        return longitude;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Point point = (Point) o;
+
+        if (Double.compare(point.latitude, latitude) != 0) {
+            return false;
+        }
+        if (Double.compare(point.longitude, longitude) != 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result;
+        long temp;
+        temp = Double.doubleToLongBits(latitude);
+        result = (int) (temp ^ (temp >>> 32));
+        temp = Double.doubleToLongBits(longitude);
+        result = 31 * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Point{"
+               + "latitude=" + latitude
+               + ", longitude=" + longitude
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/PointBuilder.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/PointBuilder.java
@@ -1,0 +1,45 @@
+package org.mongodb.morphia.geo;
+
+/**
+ * Creates Point instances representing a <a href="http://docs.mongodb.org/manual/apps/geospatial-indexes/#geojson-objects">GeoJSON</a>
+ * point type. The advantage of using the builder is to reduce confusion of the order of the latitude and longitude double values.
+ * <p/>
+ * Supported by server versions 2.4 and above.
+ *
+ * @see org.mongodb.morphia.geo.Point
+ */
+public class PointBuilder {
+    private double longitude;
+    private double latitude;
+
+    /**
+     * Add a latitude.
+     *
+     * @param latitude the latitude of the point
+     * @return this PointBuilder
+     */
+    public PointBuilder latitude(final double latitude) {
+        this.latitude = latitude;
+        return this;
+    }
+
+    /**
+     * Add a longitude.
+     *
+     * @param longitude the longitude of the point
+     * @return this PointBuilder
+     */
+    public PointBuilder longitude(final double longitude) {
+        this.longitude = longitude;
+        return this;
+    }
+
+    /**
+     * Creates an immutable point
+     *
+     * @return the Point with the specifications from this builder.
+     */
+    public Point build() {
+        return new Point(latitude, longitude);
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/geo/Polygon.java
+++ b/morphia/src/main/java/org/mongodb/morphia/geo/Polygon.java
@@ -1,0 +1,106 @@
+package org.mongodb.morphia.geo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class represents either a simple polygon enclosing an area, or a more complex polygon that contains both an exterior boundary and
+ * interior boundaries (holes) within it.  It will be persisted into the database according to <a
+ * href="http://geojson.org/geojson-spec.html#id4">the specification</a>.
+ * <p/>
+ * The factory for creating a Polygon is {@code PolygonBuilder}, which is accessible via the {@code GeoJson.polygonBuilder} method.
+ * Alternatively, simple polygons without inner rings can be created via the {@code GeoJson.polygon} factory method.
+ *
+ * @see org.mongodb.morphia.geo.GeoJson#polygon(LineString, LineString...) 
+ * @see org.mongodb.morphia.geo.GeoJson#polygon(Point...)
+ */
+public class Polygon implements Geometry {
+    private final LineString exteriorBoundary;
+    private final List<LineString> interiorBoundaries;
+
+    @SuppressWarnings("UnusedDeclaration") // used by Morphia
+    private Polygon() {
+        exteriorBoundary = null;
+        interiorBoundaries = new ArrayList<LineString>();
+    }
+
+    Polygon(final LineString exteriorBoundary, final LineString... interiorBoundaries) {
+        this.exteriorBoundary = exteriorBoundary;
+        this.interiorBoundaries = Arrays.asList(interiorBoundaries);
+    }
+
+    Polygon(final List<LineString> boundaries) {
+        exteriorBoundary = boundaries.get(0);
+        if (boundaries.size() > 1) {
+            interiorBoundaries = boundaries.subList(1, boundaries.size());
+        } else {
+            interiorBoundaries = new ArrayList<LineString>();
+        }
+    }
+
+    /**
+     * Returns a LineString representing the exterior boundary of this Polygon.  Polygons should have an exterior boundary where the end
+     * point is the same as the start point.
+     *
+     * @return a LineString containing the points that make up the external boundary of this Polygon.
+     */
+    public LineString getExteriorBoundary() {
+        return exteriorBoundary;
+    }
+
+    /**
+     * Returns a (possibly empty) List of LineStrings, one for each hole inside the external boundary of this polygon.
+     *
+     * @return a List of LineStrings where each LineString represents an internal boundary or hole.
+     */
+    public List<LineString> getInteriorBoundaries() {
+        return Collections.unmodifiableList(interiorBoundaries);
+    }
+
+    @Override
+    public List<LineString> getCoordinates() {
+        List<LineString> polygonBoundaries = new ArrayList<LineString>();
+        polygonBoundaries.add(exteriorBoundary);
+        polygonBoundaries.addAll(interiorBoundaries);
+        return polygonBoundaries;
+    }
+
+    /* equals, hashCode and toString. Useful primarily for testing and debugging. Don't forget to re-create when changing this class */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Polygon polygon = (Polygon) o;
+
+        if (!exteriorBoundary.equals(polygon.exteriorBoundary)) {
+            return false;
+        }
+        if (!interiorBoundaries.equals(polygon.interiorBoundaries)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = exteriorBoundary.hashCode();
+        result = 31 * result + interiorBoundaries.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Polygon{"
+               + "exteriorBoundary=" + exteriorBoundary
+               + ", interiorBoundaries=" + interiorBoundaries
+               + '}';
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -188,7 +188,7 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
     return addGeoCriteria(spherical ? FilterOperator.NEAR_SPHERE : FilterOperator.NEAR, new double[] {x, y}, null);
   }
 
-    private Map<String, Object> opts(final String s, final Object v) {
+  private Map<String, Object> opts(final String s, final Object v) {
     final Map<String, Object> opts = new HashMap<String, Object>();
     opts.put(s, v);
     return opts;

--- a/morphia/src/test/java/org/mongodb/morphia/ext/CustomConvertersTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/ext/CustomConvertersTest.java
@@ -24,7 +24,6 @@ import com.mongodb.DBObject;
 import com.mongodb.DefaultDBDecoder;
 import com.mongodb.DefaultDBEncoder;
 import org.bson.types.ObjectId;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mongodb.morphia.TestBase;
@@ -41,7 +40,11 @@ import javax.activation.MimeType;
 import javax.activation.MimeTypeParseException;
 import java.net.UnknownHostException;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 
 /**
@@ -79,16 +82,22 @@ public class CustomConvertersTest extends TestBase {
     }
 
     @Test
-    public void testIt() {
+    public void shouldUseSuppliedConverterToEncodeAndDecodeObject() {
+        // given
         getMorphia().map(CharEntity.class);
 
+        // when
         getDs().save(new CharEntity());
-        final CharEntity ce = getDs().find(CharEntity.class).get();
-        Assert.assertNotNull(ce.c);
-        assertEquals('a', ce.c.charValue());
 
+        // then check the representation in the database is a number
         final BasicDBObject dbObj = (BasicDBObject) getDs().getCollection(CharEntity.class).findOne();
-        Assert.assertTrue(dbObj.getInt("c") == (int) 'a');
+        assertThat(dbObj.get("c"), is(instanceOf(int.class)));
+        assertThat(dbObj.getInt("c"), is((int) 'a'));
+
+        // then check CharEntity can be decoded from the database
+        final CharEntity ce = getDs().find(CharEntity.class).get();
+        assertThat(ce.c, is(notNullValue()));
+        assertThat(ce.c.charValue(), is('a'));
     }
 
     /**

--- a/morphia/src/test/java/org/mongodb/morphia/geo/City.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/City.java
@@ -1,0 +1,56 @@
+package org.mongodb.morphia.geo;
+
+import org.mongodb.morphia.annotations.Indexed;
+import org.mongodb.morphia.utils.IndexDirection;
+
+public class City {
+    @Indexed(IndexDirection.GEO2DSPHERE)
+    private Point location;
+    private String name;
+
+    //needed for Morphia serialisation
+    @SuppressWarnings("unused")
+    public City() {
+    }
+
+    public City(final String name, final Point location) {
+        this.name = name;
+        this.location = location;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        City city = (City) o;
+
+        if (!location.equals(city.location)) {
+            return false;
+        }
+        if (!name.equals(city.name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = location.hashCode();
+        result = 31 * result + name.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "City{"
+               + "location=" + location
+               + ", name='" + name + '\''
+               + '}';
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/geo/GeoEntitiesTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/GeoEntitiesTest.java
@@ -1,0 +1,832 @@
+package org.mongodb.morphia.geo;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.testutil.JSONMatcher;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.multiPolygon;
+import static org.mongodb.morphia.geo.GeoJson.point;
+import static org.mongodb.morphia.geo.GeoJson.polygon;
+
+/**
+ * Test driving features for Issue 643 - add support for saving entities with GeoJSON.
+ */
+public class GeoEntitiesTest extends TestBase {
+    @Test
+    public void shouldSaveAnEntityWithALocationStoredAsAPoint() {
+        // given
+        City city = new City("New City", point(3.0, 7.0));
+
+        // when
+        getDs().save(city);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedCity = getDs().getCollection(City.class).findOne(new BasicDBObject("name", "New City"),
+                                                                        new BasicDBObject("_id", 0).append("className", 0));
+        assertThat(storedCity, is(notNullValue()));
+        assertThat(storedCity.toString(), JSONMatcher.jsonEqual("  {"
+                                                                + " name: 'New City',"
+                                                                + " location:  "
+                                                                + " {"
+                                                                + "  type: 'Point', "
+                                                                + "  coordinates: [7.0, 3.0]"
+                                                                + " }"
+                                                                + "}"));
+    }
+
+    @Test
+    public void shouldConvertPointCorrectlyToDBObject() {
+        // given
+        City city = new City("New City", point(3.0, 7.0));
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(city);
+
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + " name: 'New City',"
+                                                              + " className: 'org.mongodb.morphia.geo.City',"
+                                                              + " location:  "
+                                                              + " {"
+                                                              + "  type: 'Point', "
+                                                              + "  coordinates: [7.0, 3.0]"
+                                                              + " }"
+                                                              + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonPoint() {
+        // given
+        City city = new City("New City", point(3.0, 7.0));
+        getDs().save(city);
+
+        // when
+        City found = getDs().find(City.class).field("name").equal("New City").get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(city));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithALineStringGeoJsonType() {
+        // given
+        Route route = new Route("My Route", lineString(point(1, 2), point(3, 5), point(19, 13)));
+
+        // when
+        getDs().save(route);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedRoute = getDs().getCollection(Route.class).findOne(new BasicDBObject("name", "My Route"),
+                                                                          new BasicDBObject("_id", 0).append("className", 0));
+        assertThat(storedRoute, is(notNullValue()));
+        // lat/long is always long/lat on the server
+        assertThat(storedRoute.toString(), JSONMatcher.jsonEqual("  {"
+                                                                 + " name: 'My Route',"
+                                                                 + " route:"
+                                                                 + " {"
+                                                                 + "  type: 'LineString', "
+                                                                 + "  coordinates: [ [ 2.0,  1.0],"
+                                                                 + "                 [ 5.0,  3.0],"
+                                                                 + "                 [13.0, 19.0] ]"
+                                                                 + " }"
+                                                                 + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonLineString() {
+        // given
+        Route route = new Route("My Route", lineString(point(1, 2), point(3, 5), point(19, 13)));
+        getDs().save(route);
+
+        // when
+        Route found = getDs().find(Route.class).field("name").equal("My Route").get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(route));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithAPolygonGeoJsonType() {
+        // given
+        Area area = new Area("The Area", polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)));
+
+        // when
+        getDs().save(area);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedArea = getDs().getCollection(Area.class).findOne(new BasicDBObject("name", "The Area"),
+                                                                        new BasicDBObject("_id", 0)
+                                                                        .append("className", 0)
+                                                                        .append("area.className", 0));
+        assertThat(storedArea, is(notNullValue()));
+        assertThat(storedArea.toString(), JSONMatcher.jsonEqual("  {"
+                                                                + " name: 'The Area',"
+                                                                + " area:  "
+                                                                + " {"
+                                                                + "  type: 'Polygon', "
+                                                                + "  coordinates: [ [ [ 2.0, 1.1],"
+                                                                + "                   [ 3.5, 2.3],"
+                                                                + "                   [ 1.0, 3.7],"
+                                                                + "                   [ 2.0, 1.1] ] ]"
+                                                                + " }"
+                                                                + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonPolygon() {
+        // given
+        Area area = new Area("The Area", polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)));
+        getDs().save(area);
+
+        // when
+        Area found = getDs().find(Area.class).field("name").equal("The Area").get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(area));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithAPolygonContainingInteriorRings() {
+        // given
+        String polygonName = "A polygon with holes";
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+        Area area = new Area(polygonName, polygonWithHoles);
+
+        // when
+        getDs().save(area);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedArea = getDs().getCollection(Area.class).findOne(new BasicDBObject("name", polygonName),
+                                                                        new BasicDBObject("_id", 0)
+                                                                        .append("className", 0)
+                                                                        .append("area.className", 0));
+        assertThat(storedArea, is(notNullValue()));
+        assertThat(storedArea.toString(), JSONMatcher.jsonEqual("  {"
+                                                                + " name: " + polygonName + ","
+                                                                + " area:  "
+                                                                + " {"
+                                                                + "  type: 'Polygon', "
+                                                                + "  coordinates: "
+                                                                + "    [ [ [ 2.0, 1.1],"
+                                                                + "        [ 3.5, 2.3],"
+                                                                + "        [ 1.0, 3.7],"
+                                                                + "        [ 2.0, 1.1] "
+                                                                + "      ],"
+                                                                + "      [ [ 2.0, 1.5],"
+                                                                + "        [ 2.0, 1.9],"
+                                                                + "        [ 1.8, 1.9],"
+                                                                + "        [ 2.0, 1.5] "
+                                                                + "      ],"
+                                                                + "      [ [ 2.1, 2.2],"
+                                                                + "        [ 1.9, 2.4],"
+                                                                + "        [ 1.7, 2.4],"
+                                                                + "        [ 1.8, 2.1],"
+                                                                + "        [ 2.1, 2.2] "
+                                                                + "      ]"
+                                                                + "    ]"
+                                                                + " }"
+                                                                + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonMultiRingPolygon() {
+        // given
+        String polygonName = "A polygon with holes";
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+        Area area = new Area(polygonName, polygonWithHoles);
+        getDs().save(area);
+
+        // when
+        Area found = getDs().find(Area.class).field("name").equal(polygonName).get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(area));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithALocationStoredAsAMultiPoint() {
+        // given
+        String name = "My stores";
+        Stores stores = new Stores(name, GeoJson.multiPoint(point(1, 2), point(3, 5), point(19, 13)));
+
+        // when
+        getDs().save(stores);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedObject = getDs().getCollection(Stores.class).findOne(new BasicDBObject("name", name),
+                                                                            new BasicDBObject("_id", 0).append("className", 0));
+        assertThat(storedObject, is(notNullValue()));
+        assertThat(storedObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                                  + " name: " + name + ","
+                                                                  + " locations:  "
+                                                                  + " {"
+                                                                  + "  type: 'MultiPoint', "
+                                                                  + "  coordinates: [ [ 2.0,  1.0],"
+                                                                  + "                 [ 5.0,  3.0],"
+                                                                  + "                 [13.0, 19.0] ]"
+                                                                  + " }"
+                                                                  + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonMultiPoint() {
+        // given
+        String name = "My stores";
+        Stores stores = new Stores(name, GeoJson.multiPoint(point(1, 2), point(3, 5), point(19, 13)));
+        getDs().save(stores);
+
+        // when
+        Stores found = getDs().find(Stores.class).field("name").equal(name).get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(stores));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithAMultiLineStringGeoJsonType() {
+        // given
+        String name = "Many Paths";
+        Paths paths = new Paths(name, GeoJson.multiLineString(lineString(point(1, 2), point(3, 5), point(19, 13)),
+                                                              lineString(point(1.5, 2.0),
+                                                                         point(1.9, 2.0),
+                                                                         point(1.9, 1.8),
+                                                                         point(1.5, 2.0))));
+
+        // when
+        getDs().save(paths);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedPaths = getDs().getCollection(Paths.class).findOne(new BasicDBObject("name", name),
+                                                                          new BasicDBObject("_id", 0).append("className", 0));
+        assertThat(storedPaths, is(notNullValue()));
+        // lat/long is always long/lat on the server
+        assertThat(storedPaths.toString(), JSONMatcher.jsonEqual("  {"
+                                                                 + " name: '" + name + "',"
+                                                                 + " paths:"
+                                                                 + " {"
+                                                                 + "  type: 'MultiLineString', "
+                                                                 + "  coordinates: "
+                                                                 + "     [ [ [ 2.0,  1.0],"
+                                                                 + "         [ 5.0,  3.0],"
+                                                                 + "         [13.0, 19.0] "
+                                                                 + "       ], "
+                                                                 + "       [ [ 2.0, 1.5],"
+                                                                 + "         [ 2.0, 1.9],"
+                                                                 + "         [ 1.8, 1.9],"
+                                                                 + "         [ 2.0, 1.5] "
+                                                                 + "       ]"
+                                                                 + "     ]"
+                                                                 + " }"
+                                                                 + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonMultiLineString() {
+        // given
+        String name = "Many Paths";
+        Paths paths = new Paths(name, GeoJson.multiLineString(lineString(point(1, 2), point(3, 5), point(19, 13)),
+                                                              lineString(point(1.5, 2.0),
+                                                                         point(1.9, 2.0),
+                                                                         point(1.9, 1.8),
+                                                                         point(1.5, 2.0))));
+        getDs().save(paths);
+
+        // when
+        Paths found = getDs().find(Paths.class).field("name").equal(name).get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(paths));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithAMultiPolygonGeoJsonType() {
+        // given
+        String name = "All these shapes";
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8),
+                                                      point(2.2, 2.1)));
+        Regions regions = new Regions(name, multiPolygon(polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                                         polygonWithHoles));
+
+        // when
+        getDs().save(regions);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedRegions = getDs().getCollection(Regions.class).findOne(new BasicDBObject("name", name),
+                                                                              new BasicDBObject("_id", 0)
+                                                                              .append("className", 0));
+        assertThat(storedRegions, is(notNullValue()));
+        assertThat(storedRegions.toString(), JSONMatcher.jsonEqual("  {"
+                                                                   + " name: '" + name + "',"
+                                                                   + " regions:  "
+                                                                   + " {"
+                                                                   + "  type: 'MultiPolygon', "
+                                                                   + "  coordinates: [ [ [ [ 2.0, 1.1],"
+                                                                   + "                     [ 3.5, 2.3],"
+                                                                   + "                     [ 1.0, 3.7],"
+                                                                   + "                     [ 2.0, 1.1],"
+                                                                   + "                   ]"
+                                                                   + "                 ],"
+                                                                   + "                 [ [ [ 2.0, 1.1],"
+                                                                   + "                     [ 3.5, 2.3],"
+                                                                   + "                     [ 1.0, 3.7],"
+                                                                   + "                     [ 2.0, 1.1] "
+                                                                   + "                   ],"
+                                                                   + "                   [ [ 2.0, 1.5],"
+                                                                   + "                     [ 2.0, 1.9],"
+                                                                   + "                     [ 1.8, 1.9],"
+                                                                   + "                     [ 2.0, 1.5] "
+                                                                   + "                   ],"
+                                                                   + "                   [ [ 2.1, 2.2],"
+                                                                   + "                     [ 1.9, 2.4],"
+                                                                   + "                     [ 1.7, 2.4],"
+                                                                   + "                     [ 1.8, 2.1],"
+                                                                   + "                     [ 2.1, 2.2] "
+                                                                   + "                   ]"
+                                                                   + "                 ]"
+                                                                   + "               ]"
+                                                                   + " }"
+                                                                   + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoJsonMultiPolygon() {
+        // given
+        String name = "All these shapes";
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+        Regions regions = new Regions(name, multiPolygon(polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                                         polygonWithHoles));
+        getDs().save(regions);
+
+        // when
+        Regions found = getDs().find(Regions.class).field("name").equal(name).get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(regions));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithAGeoCollectionType() {
+        // given
+        String name = "What, everything?";
+        Point point = point(3.0, 7.0);
+        LineString lineString = lineString(point(1, 2), point(3, 5), point(19, 13));
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+        MultiPoint multiPoint = GeoJson.multiPoint(point(1, 2), point(3, 5), point(19, 13));
+        MultiLineString multiLineString = GeoJson.multiLineString(lineString(point(1, 2), point(3, 5), point(19, 13)),
+                                                                  lineString(point(1.5, 2.0),
+                                                                             point(1.9, 2.0),
+                                                                             point(1.9, 1.8),
+                                                                             point(1.5, 2.0)));
+        MultiPolygon multiPolygon = multiPolygon(polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                                 polygon(lineString(point(1.2, 3.0), point(2.5, 4.5), point(6.7, 1.9), point(1.2, 3.0)),
+                                                         lineString(point(3.5, 2.4), point(1.7, 2.8), point(3.5, 2.4))));
+        
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(point, lineString, polygonWithHoles, multiPoint, multiLineString,
+                                                                           multiPolygon);
+        AllTheThings allTheThings = new AllTheThings(name, geometryCollection);
+
+        // when
+        getDs().save(allTheThings);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        DBObject storedArea = getDs().getCollection(AllTheThings.class).findOne(new BasicDBObject("name", name),
+                                                                                new BasicDBObject("_id", 0)
+                                                                                .append("className", 0));
+        assertThat(storedArea, is(notNullValue()));
+        assertThat(storedArea.toString(), JSONMatcher.jsonEqual("  {"
+                                                                + " name: '" + name + "',"
+                                                                + " everything: "
+                                                                + " {"
+                                                                + "  type: 'GeometryCollection', "
+                                                                + "  geometries: "
+                                                                + "  ["
+                                                                + "    {"
+                                                                + "     type: 'Point', "
+                                                                + "     coordinates: [7.0, 3.0]"
+                                                                + "    }, "
+                                                                + "    {"
+                                                                + "     type: 'LineString', "
+                                                                + "     coordinates: [ [ 2.0,  1.0],"
+                                                                + "                    [ 5.0,  3.0],"
+                                                                + "                    [13.0, 19.0] ]"
+                                                                + "    },"
+                                                                + "    {"
+                                                                + "     type: 'Polygon', "
+                                                                + "     coordinates: "
+                                                                + "       [ [ [ 2.0, 1.1],"
+                                                                + "           [ 3.5, 2.3],"
+                                                                + "           [ 1.0, 3.7],"
+                                                                + "           [ 2.0, 1.1] "
+                                                                + "         ],"
+                                                                + "         [ [ 2.0, 1.5],"
+                                                                + "           [ 2.0, 1.9],"
+                                                                + "           [ 1.8, 1.9],"
+                                                                + "           [ 2.0, 1.5] "
+                                                                + "         ],"
+                                                                + "         [ [ 2.1, 2.2],"
+                                                                + "           [ 1.9, 2.4],"
+                                                                + "           [ 1.7, 2.4],"
+                                                                + "           [ 1.8, 2.1],"
+                                                                + "           [ 2.1, 2.2] "
+                                                                + "         ]"
+                                                                + "       ]"
+                                                                + "    },"
+                                                                + "    {"
+                                                                + "     type: 'MultiPoint', "
+                                                                + "     coordinates: [ [ 2.0,  1.0],"
+                                                                + "                    [ 5.0,  3.0],"
+                                                                + "                    [13.0, 19.0] ]"
+                                                                + "    },"
+                                                                + "    {"
+                                                                + "     type: 'MultiLineString', "
+                                                                + "     coordinates: "
+                                                                + "        [ [ [ 2.0,  1.0],"
+                                                                + "            [ 5.0,  3.0],"
+                                                                + "            [13.0, 19.0] "
+                                                                + "          ], "
+                                                                + "          [ [ 2.0, 1.5],"
+                                                                + "            [ 2.0, 1.9],"
+                                                                + "            [ 1.8, 1.9],"
+                                                                + "            [ 2.0, 1.5] "
+                                                                + "          ]"
+                                                                + "        ]"
+                                                                + "    },"
+                                                                + "    {"
+                                                                + "     type: 'MultiPolygon', "
+                                                                + "     coordinates: [ [ [ [ 2.0, 1.1],"
+                                                                + "                        [ 3.5, 2.3],"
+                                                                + "                        [ 1.0, 3.7],"
+                                                                + "                        [ 2.0, 1.1],"
+                                                                + "                      ]"
+                                                                + "                    ],"
+                                                                + "                    [ [ [ 3.0, 1.2],"
+                                                                + "                        [ 4.5, 2.5],"
+                                                                + "                        [ 1.9, 6.7],"
+                                                                + "                        [ 3.0, 1.2] "
+                                                                + "                      ],"
+                                                                + "                      [ [ 2.4, 3.5],"
+                                                                + "                        [ 2.8, 1.7],"
+                                                                + "                        [ 2.4, 3.5] "
+                                                                + "                      ],"
+                                                                + "                    ]"
+                                                                + "                  ]"
+                                                                + "    }"
+                                                                + "  ]"
+                                                                + " }"
+                                                                + "}"));
+    }
+
+    @Test
+    public void shouldRetrieveGeoCollectionType() {
+        // given
+        String name = "What, everything?";
+        Point point = point(3.0, 7.0);
+        LineString lineString = lineString(point(1, 2), point(3, 5), point(19, 13));
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+        MultiPoint multiPoint = GeoJson.multiPoint(point(1, 2), point(3, 5), point(19, 13));
+        MultiLineString multiLineString = GeoJson.multiLineString(lineString(point(1, 2), point(3, 5), point(19, 13)),
+                                                                  lineString(point(1.5, 2.0),
+                                                                             point(1.9, 2.0),
+                                                                             point(1.9, 1.8),
+                                                                             point(1.5, 2.0)));
+        MultiPolygon multiPolygon = multiPolygon(polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                                 polygon(lineString(point(1.2, 3.0), point(2.5, 4.5), point(6.7, 1.9), point(1.2, 3.0)),
+                                                         lineString(point(3.5, 2.4), point(1.7, 2.8), point(3.5, 2.4))));
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(point, lineString, polygonWithHoles, multiPoint,
+                                                                           multiLineString, multiPolygon);
+        AllTheThings allTheThings = new AllTheThings(name, geometryCollection);
+        getDs().save(allTheThings);
+
+        // when
+        AllTheThings found = getDs().find(AllTheThings.class).field("name").equal(name).get();
+
+        // then
+        assertThat(found, is(notNullValue()));
+        assertThat(found, is(allTheThings));
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class Route {
+        private String name;
+        private LineString route;
+
+        private Route() {
+        }
+
+        private Route(final String name, final LineString route) {
+            this.name = name;
+            this.route = route;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Route route1 = (Route) o;
+
+            if (name != null ? !name.equals(route1.name) : route1.name != null) {
+                return false;
+            }
+            if (route != null ? !route.equals(route1.route) : route1.route != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (route != null ? route.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Route{"
+                   + "name='" + name + '\''
+                   + ", route=" + route
+                   + '}';
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class Area {
+        private String name;
+        private Polygon area;
+
+        private Area() {
+        }
+
+        private Area(final String name, final Polygon area) {
+            this.name = name;
+            this.area = area;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Area area1 = (Area) o;
+
+            if (area != null ? !area.equals(area1.area) : area1.area != null) {
+                return false;
+            }
+            if (name != null ? !name.equals(area1.name) : area1.name != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name != null ? name.hashCode() : 0;
+            result = 31 * result + (area != null ? area.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Area{"
+                   + "name='" + name + '\''
+                   + ", area=" + area
+                   + '}';
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class Stores {
+        private String name;
+        private MultiPoint locations;
+
+        private Stores() {
+        }
+
+        private Stores(final String name, final MultiPoint locations) {
+            this.name = name;
+            this.locations = locations;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Stores stores = (Stores) o;
+
+            if (!locations.equals(stores.locations)) {
+                return false;
+            }
+            if (!name.equals(stores.name)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + locations.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Stores{"
+                   + "name='" + name + '\''
+                   + ", locations=" + locations
+                   + '}';
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class Paths {
+        private String name;
+        private MultiLineString paths;
+
+        private Paths() {
+        }
+
+        private Paths(final String name, final MultiLineString paths) {
+            this.name = name;
+            this.paths = paths;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Paths paths1 = (Paths) o;
+
+            if (!name.equals(paths1.name)) {
+                return false;
+            }
+            if (!paths.equals(paths1.paths)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + paths.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Paths{"
+                   + "name='" + name + '\''
+                   + ", paths=" + paths
+                   + '}';
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class Regions {
+        private String name;
+        private MultiPolygon regions;
+
+        private Regions() {
+        }
+
+        private Regions(final String name, final MultiPolygon regions) {
+            this.name = name;
+            this.regions = regions;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Regions regions1 = (Regions) o;
+
+            if (!name.equals(regions1.name)) {
+                return false;
+            }
+            if (!regions.equals(regions1.regions)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + regions.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Regions{"
+                   + "name='" + name + '\''
+                   + ", regions=" + regions
+                   + '}';
+        }
+    }
+
+    @SuppressWarnings("UnusedDeclaration")
+    private static final class AllTheThings {
+        private GeometryCollection everything;
+        private String name;
+
+        private AllTheThings() {
+        }
+
+        private AllTheThings(final String name, final GeometryCollection everything) {
+            this.name = name;
+            this.everything = everything;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            AllTheThings that = (AllTheThings) o;
+
+            if (!everything.equals(that.everything)) {
+                return false;
+            }
+            if (!name.equals(that.name)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = everything.hashCode();
+            result = 31 * result + name.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "AllTheThings{"
+                   + "everything=" + everything
+                   + ", name='" + name + '\''
+                   + '}';
+        }
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/geo/GeoJsonIndexTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/GeoJsonIndexTest.java
@@ -1,0 +1,34 @@
+package org.mongodb.morphia.geo;
+
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.annotations.Indexed;
+import org.mongodb.morphia.utils.IndexDirection;
+
+public class GeoJsonIndexTest extends TestBase {
+    @Test(expected = Exception.class)
+    public void shouldErrorWhenCreatingA2dIndexOnGeoJson() {
+        // given
+        Place pointB = new Place(GeoJson.point(3.1, 7.5), "Point B");
+        getDs().save(pointB);
+
+        // when
+        getDs().ensureIndexes();
+        //"location object expected, location array not in correct format", code : 13654
+    }
+
+    @SuppressWarnings("unused")
+    private static final class Place {
+        @Indexed(IndexDirection.GEO2D)
+        private Point location;
+        private String name;
+
+        private Place(final Point location, final String name) {
+            this.location = location;
+            this.name = name;
+        }
+
+        private Place() {
+        }
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/geo/GeometryCollectionTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/GeometryCollectionTest.java
@@ -1,0 +1,173 @@
+package org.mongodb.morphia.geo;
+
+import com.mongodb.DBObject;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.testutil.JSONMatcher;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.multiPolygon;
+import static org.mongodb.morphia.geo.GeoJson.point;
+import static org.mongodb.morphia.geo.GeoJson.polygon;
+
+public class GeometryCollectionTest extends TestBase {
+    @Test
+    public void shouldCorrectlySerialisePointsInGeometryCollection() {
+        // given
+        Point point = point(3.0, 7.0);
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(point);
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(geometryCollection);
+
+        // then use the underlying driver to ensure it was persisted correctly to the database
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + "  type: 'GeometryCollection', "
+                                                              + "  geometries: "
+                                                              + "  ["
+                                                              + "    {"
+                                                              + "     type: 'Point', "
+                                                              + "     coordinates: [7.0, 3.0]"
+                                                              + "    }, "
+                                                              + "  ]"
+                                                              + "}"));
+    }
+
+    @Test
+    public void shouldCorrectlySerialiseLineStringsInGeometryCollection() {
+        // given
+        LineString lineString = lineString(point(1, 2), point(3, 5), point(19, 13));
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(lineString);
+        getMorphia().getMapper().addMappedClass(Point.class);
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(geometryCollection);
+
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + "  type: 'GeometryCollection', "
+                                                              + "  geometries: "
+                                                              + "  ["
+                                                              + "    {"
+                                                              + "     type: 'LineString', "
+                                                              + "     coordinates: [ [ 2.0,  1.0],"
+                                                              + "                    [ 5.0,  3.0],"
+                                                              + "                    [13.0, 19.0] ]"
+                                                              + "    },"
+                                                              + "  ]"
+                                                              + "}"));
+    }
+
+    @Test
+    public void shouldCorrectlySerialisePolygonsInGeometryCollection() {
+        // given
+        Polygon polygonWithHoles = polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                           lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                           lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8),
+                                                      point(2.2, 2.1)));
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(polygonWithHoles);
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(geometryCollection);
+
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + "  type: 'GeometryCollection', "
+                                                              + "  geometries: "
+                                                              + "  ["
+                                                              + "    {"
+                                                              + "     type: 'Polygon', "
+                                                              + "     coordinates: "
+                                                              + "       [ [ [ 2.0, 1.1],"
+                                                              + "           [ 3.5, 2.3],"
+                                                              + "           [ 1.0, 3.7],"
+                                                              + "           [ 2.0, 1.1] "
+                                                              + "         ],"
+                                                              + "         [ [ 2.0, 1.5],"
+                                                              + "           [ 2.0, 1.9],"
+                                                              + "           [ 1.8, 1.9],"
+                                                              + "           [ 2.0, 1.5] "
+                                                              + "         ],"
+                                                              + "         [ [ 2.1, 2.2],"
+                                                              + "           [ 1.9, 2.4],"
+                                                              + "           [ 1.7, 2.4],"
+                                                              + "           [ 1.8, 2.1],"
+                                                              + "           [ 2.1, 2.2] "
+                                                              + "         ]"
+                                                              + "       ]"
+                                                              + "    },"
+                                                              + "  ]"
+                                                              + " }"
+                                                              + "}"));
+    }
+
+    @Test
+    public void shouldCorrectlySerialiseMultiPointsInGeometryCollection() {
+        // given
+        MultiPoint multiPoint = GeoJson.multiPoint(point(1, 2), point(3, 5), point(19, 13));
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(multiPoint);
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(geometryCollection);
+
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + "  type: 'GeometryCollection', "
+                                                              + "  geometries: "
+                                                              + "  ["
+                                                              + "    {"
+                                                              + "     type: 'MultiPoint', "
+                                                              + "     coordinates: [ [ 2.0,  1.0],"
+                                                              + "                    [ 5.0,  3.0],"
+                                                              + "                    [13.0, 19.0] ]"
+                                                              + "    },"
+                                                              + "  ]"
+                                                              + " }"
+                                                              + "}"));
+    }
+
+    @Test
+    public void shouldCorrectlySerialiseMultiPolygonsInGeometryCollection() {
+        // given
+        MultiPolygon multiPolygon = multiPolygon(polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0))),
+                                                 polygon(lineString(point(1.2, 3.0), point(2.5, 4.5), point(6.7, 1.9), point(1.2, 3.0)),
+                                                         lineString(point(3.5, 2.4), point(1.7, 2.8), point(3.5, 2.4))));
+        GeometryCollection geometryCollection = GeoJson.geometryCollection(multiPolygon);
+
+        // when
+        DBObject dbObject = getMorphia().toDBObject(geometryCollection);
+
+        assertThat(dbObject, is(notNullValue()));
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  {"
+                                                              + "  type: 'GeometryCollection', "
+                                                              + "  geometries: "
+                                                              + "  ["
+                                                              + "    {"
+                                                              + "     type: 'MultiPolygon', "
+                                                              + "     coordinates: [ [ [ [ 2.0, 1.1],"
+                                                              + "                        [ 3.5, 2.3],"
+                                                              + "                        [ 1.0, 3.7],"
+                                                              + "                        [ 2.0, 1.1],"
+                                                              + "                      ]"
+                                                              + "                    ],"
+                                                              + "                    [ [ [ 3.0, 1.2],"
+                                                              + "                        [ 4.5, 2.5],"
+                                                              + "                        [ 1.9, 6.7],"
+                                                              + "                        [ 3.0, 1.2] "
+                                                              + "                      ],"
+                                                              + "                      [ [ 2.4, 3.5],"
+                                                              + "                        [ 2.8, 1.7],"
+                                                              + "                        [ 2.4, 3.5] "
+                                                              + "                      ],"
+                                                              + "                    ]"
+                                                              + "                  ]"
+                                                              + "    }"
+                                                              + "  ]"
+                                                              + " }"
+                                                              + "}"));
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/geo/GeometryShapeConverterTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/GeometryShapeConverterTest.java
@@ -1,0 +1,164 @@
+package org.mongodb.morphia.geo;
+
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.testutil.JSONMatcher;
+
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.point;
+
+public class GeometryShapeConverterTest extends TestBase {
+    @Test
+    public void shouldEncodeAnEntityWithAMultiPolygonGeoJsonType() {
+        // given
+        GeometryShapeConverter.MultiPolygonConverter converter = new GeometryShapeConverter.MultiPolygonConverter();
+        converter.setMapper(getMorphia().getMapper());
+        Polygon polygonWithHoles = GeoJson.polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                                   lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                                   lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), 
+                                                              point(2.2, 2.1)));
+        MultiPolygon multiPolygon = GeoJson.multiPolygon(GeoJson.polygon(point(1.1, 2.0),
+                                                                         point(2.3, 3.5),
+                                                                         point(3.7, 1.0),
+                                                                         point(1.1, 2.0)),
+                                                         polygonWithHoles);
+
+        // when
+        Object encoded = converter.encode(multiPolygon);
+
+        // then 
+        assertThat(encoded.toString(), JSONMatcher.jsonEqual("  {"
+                                                             + "  type: 'MultiPolygon', "
+                                                             + "  coordinates: [ [ [ [ 2.0, 1.1],"
+                                                             + "                     [ 3.5, 2.3],"
+                                                             + "                     [ 1.0, 3.7],"
+                                                             + "                     [ 2.0, 1.1],"
+                                                             + "                   ]"
+                                                             + "                 ],"
+                                                             + "                 [ [ [ 2.0, 1.1],"
+                                                             + "                     [ 3.5, 2.3],"
+                                                             + "                     [ 1.0, 3.7],"
+                                                             + "                     [ 2.0, 1.1] "
+                                                             + "                   ],"
+                                                             + "                   [ [ 2.0, 1.5],"
+                                                             + "                     [ 2.0, 1.9],"
+                                                             + "                     [ 1.8, 1.9],"
+                                                             + "                     [ 2.0, 1.5] "
+                                                             + "                   ],"
+                                                             + "                   [ [ 2.1, 2.2],"
+                                                             + "                     [ 1.9, 2.4],"
+                                                             + "                     [ 1.7, 2.4],"
+                                                             + "                     [ 1.8, 2.1],"
+                                                             + "                     [ 2.1, 2.2] "
+                                                             + "                   ]"
+                                                             + "                 ]"
+                                                             + "               ]"
+                                                             + "}"));
+    }
+
+    @Test
+    public void shouldConvertAnEntityWithAPolygonGeoJsonType() {
+        // given
+        GeometryShapeConverter.PolygonConverter converter = new GeometryShapeConverter.PolygonConverter();
+        converter.setMapper(getMorphia().getMapper());
+        Polygon polygon = GeoJson.polygon(lineString(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0), point(1.1, 2.0)),
+                                          lineString(point(1.5, 2.0), point(1.9, 2.0), point(1.9, 1.8), point(1.5, 2.0)),
+                                          lineString(point(2.2, 2.1), point(2.4, 1.9), point(2.4, 1.7), point(2.1, 1.8), point(2.2, 2.1)));
+
+        // when
+        Object encodedPolygon = converter.encode(polygon);
+
+        // then 
+        assertThat(encodedPolygon.toString(), JSONMatcher.jsonEqual("  {"
+                                                                    + "  type: 'Polygon', "
+                                                                    + "  coordinates: "
+                                                                    + "    [ [ [ 2.0, 1.1],"
+                                                                    + "        [ 3.5, 2.3],"
+                                                                    + "        [ 1.0, 3.7],"
+                                                                    + "        [ 2.0, 1.1] "
+                                                                    + "      ],"
+                                                                    + "      [ [ 2.0, 1.5],"
+                                                                    + "        [ 2.0, 1.9],"
+                                                                    + "        [ 1.8, 1.9],"
+                                                                    + "        [ 2.0, 1.5] "
+                                                                    + "      ],"
+                                                                    + "      [ [ 2.1, 2.2],"
+                                                                    + "        [ 1.9, 2.4],"
+                                                                    + "        [ 1.7, 2.4],"
+                                                                    + "        [ 1.8, 2.1],"
+                                                                    + "        [ 2.1, 2.2] "
+                                                                    + "      ]"
+                                                                    + "    ]"
+                                                                    + "}"));
+    }
+
+    @Test
+    public void shouldEncodeAnEntityWithAMultiLineStringGeoJsonType() {
+        // given
+        GeometryShapeConverter.MultiLineStringConverter converter = new GeometryShapeConverter.MultiLineStringConverter();
+        converter.setMapper(getMorphia().getMapper());
+        MultiLineString multiLineString = GeoJson.multiLineString(lineString(point(1, 2), point(3, 5), point(19, 13)),
+                                                                  lineString(point(1.5, 2.0),
+                                                                             point(1.9, 2.0),
+                                                                             point(1.9, 1.8),
+                                                                             point(1.5, 2.0)));
+
+        // when
+        Object encoded = converter.encode(multiLineString);
+
+        // then 
+        assertThat(encoded.toString(), JSONMatcher.jsonEqual("  {"
+                                                             + "  type: 'MultiLineString', "
+                                                             + "  coordinates: "
+                                                             + "     [ [ [ 2.0,  1.0],"
+                                                             + "         [ 5.0,  3.0],"
+                                                             + "         [13.0, 19.0] "
+                                                             + "       ], "
+                                                             + "       [ [ 2.0, 1.5],"
+                                                             + "         [ 2.0, 1.9],"
+                                                             + "         [ 1.8, 1.9],"
+                                                             + "         [ 2.0, 1.5] "
+                                                             + "       ]"
+                                                             + "     ]"
+                                                             + "}"));
+    }
+
+    @Test
+    public void shouldSaveAnEntityWithALineStringGeoJsonType() {
+        // given
+        GeometryShapeConverter.LineStringConverter converter = new GeometryShapeConverter.LineStringConverter();
+        converter.setMapper(getMorphia().getMapper());
+        LineString lineString = lineString(point(1, 2), point(3, 5), point(19, 13));
+
+        // when
+        Object encodedLineString = converter.encode(lineString);
+
+        // then
+        assertThat(encodedLineString.toString(), JSONMatcher.jsonEqual("  {"
+                                                                       + "  type: 'LineString', "
+                                                                       + "  coordinates: [ [ 2.0,  1.0],"
+                                                                       + "                 [ 5.0,  3.0],"
+                                                                       + "                 [13.0, 19.0] ]"
+                                                                       + "}"));
+    }
+
+    @Test
+    public void shouldCorrectlyEncodePointsIntoEntityDocument() {
+        // given
+        GeometryShapeConverter.PointConverter pointConverter = new GeometryShapeConverter.PointConverter();
+        pointConverter.setMapper(getMorphia().getMapper());
+
+        Point point = point(3.0, 7.0);
+
+        // when
+        Object dbObject = pointConverter.encode(point, null);
+
+
+        // then
+        assertThat(dbObject.toString(), JSONMatcher.jsonEqual("  { "
+                                                              + "  type : 'Point' , "
+                                                              + "  coordinates : [7, 3]"
+                                                              + "}"));
+    }
+}

--- a/morphia/src/test/java/org/mongodb/morphia/query/GeoJsonTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/GeoJsonTest.java
@@ -1,0 +1,27 @@
+package org.mongodb.morphia.query;
+
+import org.junit.Test;
+import org.mongodb.morphia.geo.GeoJson;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.point;
+
+/**
+ * Unit test - more complete testing that uses the GeoJson factory is contained in functional Geo tests.
+ */
+public class GeoJsonTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldErrorIfStartAndEndOfPolygonAreNotTheSame() {
+        // expect
+        GeoJson.polygon(point(1.1, 2.0), point(2.3, 3.5), point(3.7, 1.0));
+    }
+
+    @Test
+    public void shouldNotErrorIfPolygonIsEmpty() {
+        // expect
+        assertThat(GeoJson.polygon(), is(notNullValue()));
+    }
+
+}


### PR DESCRIPTION
Fixes #643

As per discussions before the holidays, whether or not the Java driver supports geo entities in the future, I would prefer the Morphia API not to leak entities from the Java driver, and therefore it will provide its own geo entities.  In future, these may wrap or convert to entities provided by the underlying driver.