### PR TITLE
Downgrade from WARN to DEBUG message about capped collection existing (fixes #694)

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -435,7 +435,7 @@ public class DatastoreImpl implements AdvancedDatastore {
                     final DBObject dbResult = database.command(BasicDBObjectBuilder.start("collstats", collName).get());
                     if (dbResult.containsField("capped")) {
                         // TODO: check the cap options.
-                        LOG.warning("DBCollection already exists is capped already; doing nothing. " + dbResult);
+                        LOG.debug("DBCollection already exists and is capped already; doing nothing. " + dbResult);
                     } else {
                         LOG.warning("DBCollection already exists with same name(" + collName
                                     + ") and is not capped; not creating capped version!");


### PR DESCRIPTION
Sample warning being changed to debug level:

```
  WARN org.mongodb.morphia.DatastoreImpl: DBCollection already exists is capped already; doing nothing.
```

This should not be a warning as there is no problem.  The DBCollection
will already exist on every application startup except the first one.
Also fixes grammar of the log message.

Fixes Morphia issue #694.