### PR TITLE
Allow provision of custom DatastoreProvider instances for new Morphia instances

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -36,7 +36,6 @@ import org.mongodb.morphia.mapping.MappedField;
 import org.mongodb.morphia.mapping.Mapper;
 import org.mongodb.morphia.mapping.MappingException;
 import org.mongodb.morphia.mapping.cache.EntityCache;
-import org.mongodb.morphia.mapping.lazy.DatastoreHolder;
 import org.mongodb.morphia.mapping.lazy.proxy.ProxyHelper;
 import org.mongodb.morphia.query.DefaultQueryFactory;
 import org.mongodb.morphia.query.Query;
@@ -93,7 +92,7 @@ public class DatastoreImpl implements AdvancedDatastore {
         db = mongoClient.getDB(dbName);
 
         // VERY discussable
-        DatastoreHolder.getInstance().set(this);
+        mapper.getDatastoreProvider().register(this);
     }
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -105,7 +105,7 @@ public class Mapper {
 
     // TODO: make these configurable
     private final LazyProxyFactory proxyFactory = LazyFeatureDependencies.createDefaultProxyFactory();
-    private final DatastoreProvider datastoreProvider = new DefaultDatastoreProvider();
+    private DatastoreProvider datastoreProvider = new DefaultDatastoreProvider();
     private final DefaultConverters converters = new DefaultConverters();
 
     public Mapper() {
@@ -115,6 +115,11 @@ public class Mapper {
     public Mapper(final MapperOptions opts) {
         this();
         this.opts = opts;
+    }
+    
+    public Mapper(final DatastoreProvider datastoreProvider) {
+        this();
+        this.datastoreProvider = datastoreProvider;
     }
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/DatastoreProvider.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/DatastoreProvider.java
@@ -15,4 +15,6 @@ import org.mongodb.morphia.Datastore;
  */
 public interface DatastoreProvider extends Serializable {
   Datastore get();
+
+  void register(Datastore ds);
 }

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/DefaultDatastoreProvider.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/DefaultDatastoreProvider.java
@@ -21,4 +21,9 @@ public class DefaultDatastoreProvider implements DatastoreProvider {
     return datastore;
   }
 
+  @Override
+  public void register(final Datastore ds) {
+     DatastoreHolder.getInstance().set(ds);
+  }
+
 }

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/SingleDatastoreProvider.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/SingleDatastoreProvider.java
@@ -1,0 +1,33 @@
+package org.mongodb.morphia.mapping.lazy;
+
+import org.mongodb.morphia.Datastore;
+
+/**
+ * This will only ever return the first datastore created by an associated
+ * Mapper instance
+ * 
+ * @author Michael Houston
+ */
+public class SingleDatastoreProvider implements DatastoreProvider {
+
+    private static final long serialVersionUID = 1L;
+
+    private Datastore datastore;
+
+    @Override
+    public Datastore get() {
+        if (datastore == null) {
+            throw new IllegalStateException(
+                    "SingleDatastoreProvider does not carry a Datastore.");
+        }
+        return datastore;
+    }
+
+    @Override
+    public void register(final Datastore ds) {
+        if (datastore == null) {
+            datastore = ds;
+        }
+    }
+
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/ThreadLocalDatastoreProvider.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/ThreadLocalDatastoreProvider.java
@@ -1,0 +1,31 @@
+package org.mongodb.morphia.mapping.lazy;
+
+import org.mongodb.morphia.Datastore;
+
+/**
+ * Stores one active datastore per thread, based on the most recently registered datastore
+ * 
+ * @author Michael Houston
+ */
+public class ThreadLocalDatastoreProvider implements DatastoreProvider {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ThreadLocal<Datastore> datastores = new ThreadLocal<Datastore>();
+
+    @Override
+    public Datastore get() {
+        Datastore datastore = datastores.get();
+        if (datastore == null) {
+            throw new IllegalStateException(
+                    "ThreadLocal does not carry a Datastore for this thread.");
+        }
+        return datastore;
+    }
+
+    @Override
+    public void register(final Datastore ds) {
+        datastores.set(ds);
+    }
+
+}


### PR DESCRIPTION
This patch supersedes #728, and is branched from the current head.