### PR TITLE
Issue 645 - Added support for $geoIntersects

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -118,4 +118,14 @@ public interface FieldEnd<T> {
      * @return T
      */
     T within(MultiPolygon boundaries);
+
+    /**
+     * This performs a $geoIntersects query, searching documents containing any sort of GeoJson field and returning
+     * those where the given point intersects with the document shape.  This includes cases where the data and the
+     * specified object share an edge.
+     *
+     * @param point the co-ordinates to use to find any intersecting shapes.
+     * @return any documents where the GeoJson intersects with a specified {@code point}.
+     */
+    T intersects(Point point);
 }

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -1,6 +1,7 @@
 package org.mongodb.morphia.query;
 
 
+import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.MultiPolygon;
 import org.mongodb.morphia.geo.Point;
 import org.mongodb.morphia.geo.Polygon;
@@ -121,11 +122,11 @@ public interface FieldEnd<T> {
 
     /**
      * This performs a $geoIntersects query, searching documents containing any sort of GeoJson field and returning
-     * those where the given point intersects with the document shape.  This includes cases where the data and the
+     * those where the given geometry intersects with the document shape.  This includes cases where the data and the
      * specified object share an edge.
      *
-     * @param point the co-ordinates to use to find any intersecting shapes.
-     * @return any documents where the GeoJson intersects with a specified {@code point}.
+     * @param geometry the shape to use to query for any stored shapes that intersect
+     * @return any documents where the GeoJson intersects with a specified {@code geometry}.
      */
-    T intersects(Point point);
+    T intersects(Geometry geometry);
 }

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.mongodb.morphia.query.FilterOperator.GEO_WITHIN;
+import static org.mongodb.morphia.query.FilterOperator.INTERSECTS;
 
 
 public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T> {
@@ -223,8 +224,15 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
         opts.put(s, v);
         return opts;
     }
-  
+
+    @Override
     public T type(final Type type) {
       return addCriteria(FilterOperator.TYPE, type.val());
+    }
+
+    @Override
+    public T intersects(final Point point) {
+        target.add(new StandardGeoFieldCriteria(query, field, INTERSECTS, point, null, validateName, false));
+        return target;
     }
 }

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -1,6 +1,7 @@
 package org.mongodb.morphia.query;
 
 
+import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.MultiPolygon;
 import org.mongodb.morphia.geo.Point;
 import org.mongodb.morphia.geo.Polygon;
@@ -231,8 +232,8 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
     }
 
     @Override
-    public T intersects(final Point point) {
-        target.add(new StandardGeoFieldCriteria(query, field, INTERSECTS, point, null, validateName, false));
+    public T intersects(final Geometry geometry) {
+        target.add(new StandardGeoFieldCriteria(query, field, INTERSECTS, geometry, null, validateName, false));
         return target;
     }
 }

--- a/morphia/src/main/java/org/mongodb/morphia/query/FilterOperator.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FilterOperator.java
@@ -60,18 +60,9 @@ public enum FilterOperator {
     @Deprecated
     WITHIN("$within", "within"),
     
-    GEO_WITHIN("$geoWithin", "geoWithin") {
-/*
-        @Override
-        public boolean matches(final String filter) {
-            boolean match = "within".equals(filter);
-            if (match) {
-                LOG.warning("'within' is a deprecated operator.  Please use geoWithin instead.");
-            }
-            return match || "geoWithin".equals(filter);
-        }
-*/
-    };
+    GEO_WITHIN("$geoWithin", "geoWithin"),
+
+    INTERSECTS("$geoIntersects", "geoIntersects");
 
     private final String value;
     private final List<String> filters;

--- a/morphia/src/main/java/org/mongodb/morphia/query/StandardGeoFieldCriteria.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/StandardGeoFieldCriteria.java
@@ -5,7 +5,6 @@ import com.mongodb.DBObject;
 import org.mongodb.morphia.geo.Geometry;
 import org.mongodb.morphia.geo.GeometryQueryConverter;
 
-import static org.mongodb.morphia.query.FilterOperator.GEO_WITHIN;
 import static org.mongodb.morphia.query.FilterOperator.NEAR;
 
 /**
@@ -37,7 +36,8 @@ class StandardGeoFieldCriteria extends FieldCriteria {
                 query = BasicDBObjectBuilder.start(NEAR.val(), geometryAsDBObject);
                 break;
             case GEO_WITHIN:
-                query = BasicDBObjectBuilder.start(GEO_WITHIN.val(), geometryAsDBObject);
+            case INTERSECTS:
+                query = BasicDBObjectBuilder.start(operator.val(), geometryAsDBObject);
                 break;
             default:
                 throw new UnsupportedOperationException(String.format("Operator %s not supported for geo-query", operator.val()));

--- a/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithLineTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithLineTest.java
@@ -1,0 +1,226 @@
+package org.mongodb.morphia.query;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.geo.AllTheThings;
+import org.mongodb.morphia.geo.Area;
+import org.mongodb.morphia.geo.City;
+import org.mongodb.morphia.geo.LineString;
+import org.mongodb.morphia.geo.Regions;
+import org.mongodb.morphia.geo.Route;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.geometryCollection;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.multiPoint;
+import static org.mongodb.morphia.geo.GeoJson.multiPolygon;
+import static org.mongodb.morphia.geo.GeoJson.point;
+import static org.mongodb.morphia.geo.GeoJson.polygon;
+
+public class GeoIntersectsQueriesWithLineTest extends TestBase {
+    @Before
+    public void setUp() {
+        // this whole test class is designed for "modern" geo queries
+        checkMinServerVersion(2.4);
+        super.setUp();
+    }
+
+    @Test
+    public void shouldFindAPointThatLiesOnTheQueryLine() {
+        // given
+        LineString spanishLine = lineString(point(37.40759155713022, -5.964911067858338),
+                                            point(37.3753708, -5.9550582));
+        City manchester = new City("Manchester", point(53.4722454, -2.2235922));
+        getDs().save(manchester);
+        City london = new City("London", point(51.5286416, -0.1015987));
+        getDs().save(london);
+        City sevilla = new City("Sevilla", point(37.3753708, -5.9550582));
+        getDs().save(sevilla);
+
+        getDs().ensureIndexes();
+
+        // when
+        List<City> matchingCity = getDs().find(City.class)
+                                         .field("location")
+                                         .intersects(spanishLine)
+                                         .asList();
+
+        // then
+        assertThat(matchingCity.size(), is(1));
+        assertThat(matchingCity.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindRoutesThatALineCrosses() {
+        // given
+        Route sevilla = new Route("Spain", lineString(point(37.4045286, -5.9642332),
+                                                      point(37.4061095, -5.9645765)));
+        getDs().save(sevilla);
+        Route newYork = new Route("New York", lineString(point(40.75981395319104, -73.98302106186748),
+                                                         point(40.7636824529618, -73.98049869574606),
+                                                         point(40.76962974853814, -73.97964206524193)));
+        getDs().save(newYork);
+        Route london = new Route("London", lineString(point(51.507780365645885, -0.21786745637655258),
+                                                      point(51.50802478194237, -0.21474729292094707),
+                                                      point(51.5086863655597, -0.20895397290587425)));
+        getDs().save(london);
+        Route londonToParis = new Route("London To Paris", lineString(point(51.5286416, -0.1015987),
+                                                                      point(48.858859, 2.3470599)));
+        getDs().save(londonToParis);
+        getDs().ensureIndexes();
+
+        // when
+        List<Route> routeContainingPoint = getDs().find(Route.class)
+                                                  .field("route")
+                                                  .intersects(lineString(point(37.4043709, -5.9643244),
+                                                                         point(37.4045286, -5.9642332)))
+                                                  .asList();
+
+        // then
+        assertThat(routeContainingPoint.size(), is(1));
+        assertThat(routeContainingPoint.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindAreasThatALineCrosses() {
+        // given
+        Area sevilla = new Area("Spain",
+                                polygon(point(37.40759155713022, -5.964911067858338),
+                                        point(37.40341208875179, -5.9643941558897495),
+                                        point(37.40297396667302, -5.970452763140202),
+                                        point(37.40759155713022, -5.964911067858338))
+        );
+        getDs().save(sevilla);
+        Area newYork = new Area("New York",
+                                polygon(point(40.75981395319104, -73.98302106186748),
+                                        point(40.7636824529618, -73.98049869574606),
+                                        point(40.76962974853814, -73.97964206524193),
+                                        point(40.75981395319104, -73.98302106186748)));
+        getDs().save(newYork);
+        Area london = new Area("London",
+                               polygon(point(51.507780365645885, -0.21786745637655258),
+                                       point(51.50802478194237, -0.21474729292094707),
+                                       point(51.5086863655597, -0.20895397290587425),
+                                       point(51.507780365645885, -0.21786745637655258)));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Area> areaContainingPoint = getDs().find(Area.class)
+                                                .field("area")
+                                                .intersects(lineString(point(37.4056048, -5.9666089),
+                                                                       point(37.404497, -5.9640557)))
+                                                .asList();
+
+        // then
+        assertThat(areaContainingPoint.size(), is(1));
+        assertThat(areaContainingPoint.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindRegionsThatALineCrosses() {
+        checkMinServerVersion(2.6);
+        // given
+        Regions sevilla = new Regions("Spain", multiPolygon(polygon(point(37.40759155713022, -5.964911067858338),
+                                                                    point(37.40341208875179, -5.9643941558897495),
+                                                                    point(37.40297396667302, -5.970452763140202),
+                                                                    point(37.40759155713022, -5.964911067858338)),
+                                                            polygon(point(37.38744598813355, -6.001141928136349),
+                                                                    point(37.385990973562, -6.002588979899883),
+                                                                    point(37.386126928031445, -6.002463921904564),
+                                                                    point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                                                             point(40.7636824529618, -73.98049869574606),
+                                                             point(40.76962974853814, -73.97964206524193),
+                                                             point(40.75981395319104, -73.98302106186748)),
+                                                     polygon(point(28.326568258926272, -81.60542246885598),
+                                                             point(28.327541397884488, -81.6022228449583),
+                                                             point(28.32950334995985, -81.60564735531807),
+                                                             point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        Regions london = new Regions("London", multiPolygon(polygon(point(51.507780365645885, -0.21786745637655258),
+                                                                    point(51.50802478194237, -0.21474729292094707),
+                                                                    point(51.5086863655597, -0.20895397290587425),
+                                                                    point(51.507780365645885, -0.21786745637655258)),
+                                                            polygon(point(51.498216362670064, 0.0074849557131528854),
+                                                                    point(51.49176875129342, 0.01821178011596203),
+                                                                    point(51.492886897176504, 0.05523204803466797),
+                                                                    point(51.49393044412136, 0.06663135252892971),
+                                                                    point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Regions> regionsInTheUK = getDs().find(Regions.class)
+                                              .field("regions")
+                                              .intersects(lineString(point(37.4056048, -5.9666089),
+                                                                     point(37.404497, -5.9640557)))
+                                              .asList();
+
+        // then
+        assertThat(regionsInTheUK.size(), is(1));
+        assertThat(regionsInTheUK.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindGeometryCollectionsWhereTheGivenPointIntersectsWithOneOfTheEntities() {
+        checkMinServerVersion(2.6);
+        // given
+        AllTheThings sevilla = new AllTheThings("Spain", geometryCollection(
+                multiPoint(point(37.40759155713022, -5.964911067858338),
+                           point(37.40341208875179, -5.9643941558897495),
+                           point(37.40297396667302, -5.970452763140202)),
+                polygon(point(37.40759155713022, -5.964911067858338),
+                        point(37.40341208875179, -5.9643941558897495),
+                        point(37.40297396667302, -5.970452763140202),
+                        point(37.40759155713022, -5.964911067858338)),
+                polygon(point(37.38744598813355, -6.001141928136349),
+                        point(37.385990973562, -6.002588979899883),
+                        point(37.386126928031445, -6.002463921904564),
+                        point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        // insert something that's not a geocollection
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                                                             point(40.7636824529618, -73.98049869574606),
+                                                             point(40.76962974853814, -73.97964206524193),
+                                                             point(40.75981395319104, -73.98302106186748)),
+                                                     polygon(point(28.326568258926272, -81.60542246885598),
+                                                             point(28.327541397884488, -81.6022228449583),
+                                                             point(28.32950334995985, -81.60564735531807),
+                                                             point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        AllTheThings london = new AllTheThings("London", geometryCollection(
+                point(53.4722454, -2.2235922),
+                lineString(point(51.507780365645885, -0.21786745637655258),
+                           point(51.50802478194237, -0.21474729292094707),
+                           point(51.5086863655597, -0.20895397290587425)),
+                polygon(point(51.498216362670064, 0.0074849557131528854),
+                        point(51.49176875129342, 0.01821178011596203),
+                        point(51.492886897176504, 0.05523204803466797),
+                        point(51.49393044412136, 0.06663135252892971),
+                        point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<AllTheThings> everythingInTheUK = getDs().find(AllTheThings.class)
+                                                      .field("everything")
+                                                      .intersects(lineString(point(37.4056048, -5.9666089),
+                                                                             point(37.404497, -5.9640557)))
+                                                      .asList();
+
+        // then
+        assertThat(everythingInTheUK.size(), is(1));
+        assertThat(everythingInTheUK.get(0), is(sevilla));
+    }
+
+}

--- a/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithPointTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithPointTest.java
@@ -1,0 +1,225 @@
+package org.mongodb.morphia.query;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.geo.AllTheThings;
+import org.mongodb.morphia.geo.Area;
+import org.mongodb.morphia.geo.City;
+import org.mongodb.morphia.geo.Point;
+import org.mongodb.morphia.geo.Regions;
+import org.mongodb.morphia.geo.Route;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.geometryCollection;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.multiPoint;
+import static org.mongodb.morphia.geo.GeoJson.multiPolygon;
+import static org.mongodb.morphia.geo.GeoJson.point;
+import static org.mongodb.morphia.geo.GeoJson.polygon;
+import static org.mongodb.morphia.geo.PointBuilder.pointBuilder;
+
+public class GeoIntersectsQueriesWithPointTest extends TestBase {
+    @Before
+    public void setUp() {
+        // this whole test class is designed for "modern" geo queries
+        checkMinServerVersion(2.4);
+        super.setUp();
+    }
+
+    @Test
+    public void shouldFindAPointThatExactlyMatchesTheQueryPoint() {
+        // given
+        Point coordsOfManchester = point(53.4722454, -2.2235922);
+        City manchester = new City("Manchester", coordsOfManchester);
+        getDs().save(manchester);
+        City london = new City("London", point(51.5286416, -0.1015987));
+        getDs().save(london);
+        City sevilla = new City("Sevilla", point(37.3753708, -5.9550582));
+        getDs().save(sevilla);
+
+        getDs().ensureIndexes();
+
+        // when
+        List<City> matchingCity = getDs().find(City.class)
+                                         .field("location")
+                                         .intersects(coordsOfManchester)
+                                         .asList();
+
+        // then
+        assertThat(matchingCity.size(), is(1));
+        assertThat(matchingCity.get(0), is(manchester));
+    }
+
+    @Test
+    public void shouldFindRoutesThatAGivenPointIsOn() {
+        // given
+        Route sevilla = new Route("Spain", lineString(pointBuilder().latitude(37.40759155713022)
+                                                                    .longitude(-5.964911067858338).build(),
+                pointBuilder().latitude(37.40341208875179).longitude(-5.9643941558897495).build(),
+                pointBuilder().latitude(37.40297396667302).longitude(-5.970452763140202).build()));
+        getDs().save(sevilla);
+        Route newYork = new Route("New York", lineString(pointBuilder().latitude(40.75981395319104)
+                                                                       .longitude(-73.98302106186748).build(),
+                pointBuilder().latitude(40.7636824529618).longitude(-73.98049869574606).build(),
+                pointBuilder().latitude(40.76962974853814).longitude(-73.97964206524193).build()));
+        getDs().save(newYork);
+        Route london = new Route("London", lineString(pointBuilder().latitude(51.507780365645885)
+                                                                    .longitude(-0.21786745637655258).build(),
+                pointBuilder().latitude(51.50802478194237).longitude(-0.21474729292094707).build(),
+                pointBuilder().latitude(51.5086863655597).longitude(-0.20895397290587425).build()));
+        getDs().save(london);
+        Route londonToParis = new Route("London To Paris", lineString(pointBuilder().latitude(51.5286416)
+                                                                                    .longitude(-0.1015987).build(),
+                pointBuilder().latitude(48.858859).longitude(2.3470599).build()));
+        getDs().save(londonToParis);
+        getDs().ensureIndexes();
+
+        // when
+        List<Route> routeContainingPoint = getDs().find(Route.class)
+                                                  .field("route")
+                                                  .intersects(point(37.40759155713022, -5.964911067858338))
+                                                  .asList();
+
+        // then
+        assertThat(routeContainingPoint.size(), is(1));
+        assertThat(routeContainingPoint.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindAreasWhereTheGivenPointIsOnTheBoundary() {
+        // given
+        Area sevilla = new Area("Spain",
+                polygon(pointBuilder().latitude(37.40759155713022).longitude(-5.964911067858338).build(),
+                        pointBuilder().latitude(37.40341208875179).longitude(-5.9643941558897495).build(),
+                        pointBuilder().latitude(37.40297396667302).longitude(-5.970452763140202).build(),
+                        pointBuilder().latitude(37.40759155713022).longitude(-5.964911067858338).build())
+        );
+        getDs().save(sevilla);
+        Area newYork = new Area("New York",
+                polygon(pointBuilder().latitude(40.75981395319104).longitude(-73.98302106186748).build(),
+                        pointBuilder().latitude(40.7636824529618).longitude(-73.98049869574606).build(),
+                        pointBuilder().latitude(40.76962974853814).longitude(-73.97964206524193).build(),
+                        pointBuilder().latitude(40.75981395319104).longitude(-73.98302106186748).build()));
+        getDs().save(newYork);
+        Area london = new Area("London",
+                polygon(pointBuilder().latitude(51.507780365645885).longitude(-0.21786745637655258).build(),
+                        pointBuilder().latitude(51.50802478194237).longitude(-0.21474729292094707).build(),
+                        pointBuilder().latitude(51.5086863655597).longitude(-0.20895397290587425).build(),
+                        pointBuilder().latitude(51.507780365645885).longitude(-0.21786745637655258).build()));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Area> areaContainingPoint = getDs().find(Area.class)
+                                           .field("area")
+                                           .intersects(point(51.507780365645885, -0.21786745637655258))
+                                           .asList();
+
+        // then
+        assertThat(areaContainingPoint.size(), is(1));
+        assertThat(areaContainingPoint.get(0), is(london));
+    }
+
+    @Test
+    public void shouldFindRegionsWhereTheGivenPointIsOnABoundary() {
+        checkMinServerVersion(2.6);
+        // given
+        Regions sevilla = new Regions("Spain", multiPolygon(polygon(point(37.40759155713022, -5.964911067858338),
+                        point(37.40341208875179, -5.9643941558897495),
+                        point(37.40297396667302, -5.970452763140202),
+                        point(37.40759155713022, -5.964911067858338)),
+                polygon(point(37.38744598813355, -6.001141928136349),
+                        point(37.385990973562, -6.002588979899883),
+                        point(37.386126928031445, -6.002463921904564),
+                        point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                        point(40.7636824529618, -73.98049869574606),
+                        point(40.76962974853814, -73.97964206524193),
+                        point(40.75981395319104, -73.98302106186748)),
+                polygon(point(28.326568258926272, -81.60542246885598),
+                        point(28.327541397884488, -81.6022228449583),
+                        point(28.32950334995985, -81.60564735531807),
+                        point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        Regions london = new Regions("London", multiPolygon(polygon(point(51.507780365645885, -0.21786745637655258),
+                        point(51.50802478194237, -0.21474729292094707),
+                        point(51.5086863655597, -0.20895397290587425),
+                        point(51.507780365645885, -0.21786745637655258)),
+                polygon(point(51.498216362670064, 0.0074849557131528854),
+                        point(51.49176875129342, 0.01821178011596203),
+                        point(51.492886897176504, 0.05523204803466797),
+                        point(51.49393044412136, 0.06663135252892971),
+                        point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Regions> regionsInTheUK = getDs().find(Regions.class)
+                                              .field("regions")
+                                              .intersects(point(51.498216362670064, 0.0074849557131528854))
+                                              .asList();
+
+        // then
+        assertThat(regionsInTheUK.size(), is(1));
+        assertThat(regionsInTheUK.get(0), is(london));
+    }
+
+    @Test
+    public void shouldFindGeometryCollectionsWhereTheGivenPointIntersectsWithOneOfTheEntities() {
+        checkMinServerVersion(2.6);
+        // given
+        AllTheThings sevilla = new AllTheThings("Spain", geometryCollection(multiPoint(point(37.40759155713022, -5.964911067858338),
+                        point(37.40341208875179, -5.9643941558897495),
+                        point(37.40297396667302, -5.970452763140202)),
+                polygon(point(37.40759155713022, -5.964911067858338),
+                        point(37.40341208875179, -5.9643941558897495),
+                        point(37.40297396667302, -5.970452763140202),
+                        point(37.40759155713022, -5.964911067858338)),
+                polygon(point(37.38744598813355, -6.001141928136349),
+                        point(37.385990973562, -6.002588979899883),
+                        point(37.386126928031445, -6.002463921904564),
+                        point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        // insert something that's not a geocollection
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                        point(40.7636824529618, -73.98049869574606),
+                        point(40.76962974853814, -73.97964206524193),
+                        point(40.75981395319104, -73.98302106186748)),
+                polygon(point(28.326568258926272, -81.60542246885598),
+                        point(28.327541397884488, -81.6022228449583),
+                        point(28.32950334995985, -81.60564735531807),
+                        point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        AllTheThings london = new AllTheThings("London", geometryCollection(point(53.4722454, -2.2235922),
+                lineString(point(51.507780365645885, -0.21786745637655258),
+                        point(51.50802478194237, -0.21474729292094707),
+                        point(51.5086863655597, -0.20895397290587425)),
+                polygon(point(51.498216362670064, 0.0074849557131528854),
+                        point(51.49176875129342, 0.01821178011596203),
+                        point(51.492886897176504, 0.05523204803466797),
+                        point(51.49393044412136, 0.06663135252892971),
+                        point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<AllTheThings> everythingInTheUK = getDs().find(AllTheThings.class)
+                                                      .field("everything")
+                                                      .intersects(point(51.50802478194237, -0.21474729292094707))
+                                                      .asList();
+
+        // then
+        assertThat(everythingInTheUK.size(), is(1));
+        assertThat(everythingInTheUK.get(0), is(london));
+    }
+
+}

--- a/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithPolygonTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/GeoIntersectsQueriesWithPolygonTest.java
@@ -1,0 +1,234 @@
+package org.mongodb.morphia.query;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.geo.AllTheThings;
+import org.mongodb.morphia.geo.Area;
+import org.mongodb.morphia.geo.City;
+import org.mongodb.morphia.geo.Regions;
+import org.mongodb.morphia.geo.Route;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mongodb.morphia.geo.GeoJson.geometryCollection;
+import static org.mongodb.morphia.geo.GeoJson.lineString;
+import static org.mongodb.morphia.geo.GeoJson.multiPoint;
+import static org.mongodb.morphia.geo.GeoJson.multiPolygon;
+import static org.mongodb.morphia.geo.GeoJson.point;
+import static org.mongodb.morphia.geo.GeoJson.polygon;
+
+public class GeoIntersectsQueriesWithPolygonTest extends TestBase {
+    @Before
+    public void setUp() {
+        // this whole test class is designed for "modern" geo queries
+        checkMinServerVersion(2.4);
+        super.setUp();
+    }
+
+    @Test
+    public void shouldFindAPointThatLiesInAQueryPolygon() {
+        // given
+        City manchester = new City("Manchester", point(53.4722454, -2.2235922));
+        getDs().save(manchester);
+        City london = new City("London", point(51.5286416, -0.1015987));
+        getDs().save(london);
+        City sevilla = new City("Sevilla", point(37.4057731, -5.966287));
+        getDs().save(sevilla);
+
+        getDs().ensureIndexes();
+
+        // when
+        List<City> matchingCity = getDs().find(City.class)
+                                         .field("location")
+                                         .intersects(polygon(point(37.40759155713022, -5.964911067858338),
+                                                             point(37.40341208875179, -5.9643941558897495),
+                                                             point(37.40297396667302, -5.970452763140202),
+                                                             point(37.40759155713022, -5.964911067858338)))
+                                         .asList();
+
+        // then
+        assertThat(matchingCity.size(), is(1));
+        assertThat(matchingCity.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindRoutesThatCrossAQueryPolygon() {
+        // given
+        Route sevilla = new Route("Spain", lineString(point(37.4056048, -5.9666089),
+                                                      point(37.404497, -5.9640557)));
+        getDs().save(sevilla);
+        Route newYork = new Route("New York", lineString(point(40.75981395319104, -73.98302106186748),
+                                                         point(40.7636824529618, -73.98049869574606),
+                                                         point(40.76962974853814, -73.97964206524193)));
+        getDs().save(newYork);
+        Route london = new Route("London", lineString(point(51.507780365645885, -0.21786745637655258),
+                                                      point(51.50802478194237, -0.21474729292094707),
+                                                      point(51.5086863655597, -0.20895397290587425)));
+        getDs().save(london);
+        Route londonToParis = new Route("London To Paris", lineString(point(51.5286416, -0.1015987),
+                                                                      point(48.858859, 2.3470599)));
+        getDs().save(londonToParis);
+        getDs().ensureIndexes();
+
+        // when
+        List<Route> routeContainingPoint = getDs().find(Route.class)
+                                                  .field("route")
+                                                  .intersects(polygon(point(37.40759155713022, -5.964911067858338),
+                                                                      point(37.40341208875179, -5.9643941558897495),
+                                                                      point(37.40297396667302, -5.970452763140202),
+                                                                      point(37.40759155713022, -5.964911067858338)))
+                                                  .asList();
+
+        // then
+        assertThat(routeContainingPoint.size(), is(1));
+        assertThat(routeContainingPoint.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindAreasThatAPolygonIntersects() {
+        // given
+        Area sevilla = new Area("Spain",
+                                polygon(point(37.40759155713022, -5.964911067858338),
+                                        point(37.40341208875179, -5.9643941558897495),
+                                        point(37.40297396667302, -5.970452763140202),
+                                        point(37.40759155713022, -5.964911067858338))
+        );
+        getDs().save(sevilla);
+        Area newYork = new Area("New York",
+                                polygon(point(40.75981395319104, -73.98302106186748),
+                                        point(40.7636824529618, -73.98049869574606),
+                                        point(40.76962974853814, -73.97964206524193),
+                                        point(40.75981395319104, -73.98302106186748)));
+        getDs().save(newYork);
+        Area london = new Area("London",
+                               polygon(point(51.507780365645885, -0.21786745637655258),
+                                       point(51.50802478194237, -0.21474729292094707),
+                                       point(51.5086863655597, -0.20895397290587425),
+                                       point(51.507780365645885, -0.21786745637655258)));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Area> areaContainingPoint = getDs().find(Area.class)
+                                                .field("area")
+                                                .intersects(polygon(point(37.4056048, -5.9666089),
+                                                                    point(37.404497, -5.9640557),
+                                                                    point(37.407239, -5.962988),
+                                                                    point(37.4056048, -5.9666089)))
+                                                .asList();
+
+        // then
+        assertThat(areaContainingPoint.size(), is(1));
+        assertThat(areaContainingPoint.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindRegionsThatAPolygonCrosses() {
+        checkMinServerVersion(2.6);
+        // given
+        Regions sevilla = new Regions("Spain", multiPolygon(polygon(point(37.40759155713022, -5.964911067858338),
+                                                                    point(37.40341208875179, -5.9643941558897495),
+                                                                    point(37.40297396667302, -5.970452763140202),
+                                                                    point(37.40759155713022, -5.964911067858338)),
+                                                            polygon(point(37.38744598813355, -6.001141928136349),
+                                                                    point(37.385990973562, -6.002588979899883),
+                                                                    point(37.386126928031445, -6.002463921904564),
+                                                                    point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                                                             point(40.7636824529618, -73.98049869574606),
+                                                             point(40.76962974853814, -73.97964206524193),
+                                                             point(40.75981395319104, -73.98302106186748)),
+                                                     polygon(point(28.326568258926272, -81.60542246885598),
+                                                             point(28.327541397884488, -81.6022228449583),
+                                                             point(28.32950334995985, -81.60564735531807),
+                                                             point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        Regions london = new Regions("London", multiPolygon(polygon(point(51.507780365645885, -0.21786745637655258),
+                                                                    point(51.50802478194237, -0.21474729292094707),
+                                                                    point(51.5086863655597, -0.20895397290587425),
+                                                                    point(51.507780365645885, -0.21786745637655258)),
+                                                            polygon(point(51.498216362670064, 0.0074849557131528854),
+                                                                    point(51.49176875129342, 0.01821178011596203),
+                                                                    point(51.492886897176504, 0.05523204803466797),
+                                                                    point(51.49393044412136, 0.06663135252892971),
+                                                                    point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<Regions> regionsInTheUK = getDs().find(Regions.class)
+                                              .field("regions")
+                                              .intersects(polygon(point(37.4056048, -5.9666089),
+                                                                  point(37.404497, -5.9640557),
+                                                                  point(37.407239, -5.962988),
+                                                                  point(37.4056048, -5.9666089)))
+                                              .asList();
+
+        // then
+        assertThat(regionsInTheUK.size(), is(1));
+        assertThat(regionsInTheUK.get(0), is(sevilla));
+    }
+
+    @Test
+    public void shouldFindGeometryCollectionsWhereTheGivenPointIntersectsWithOneOfTheEntities() {
+        checkMinServerVersion(2.6);
+        // given
+        AllTheThings sevilla = new AllTheThings("Spain", geometryCollection(
+                multiPoint(point(37.40759155713022, -5.964911067858338),
+                           point(37.40341208875179, -5.9643941558897495),
+                           point(37.40297396667302, -5.970452763140202)),
+                polygon(point(37.40759155713022, -5.964911067858338),
+                        point(37.40341208875179, -5.9643941558897495),
+                        point(37.40297396667302, -5.970452763140202),
+                        point(37.40759155713022, -5.964911067858338)),
+                polygon(point(37.38744598813355, -6.001141928136349),
+                        point(37.385990973562, -6.002588979899883),
+                        point(37.386126928031445, -6.002463921904564),
+                        point(37.38744598813355, -6.001141928136349))));
+        getDs().save(sevilla);
+
+        // insert something that's not a geocollection
+        Regions usa = new Regions("US", multiPolygon(polygon(point(40.75981395319104, -73.98302106186748),
+                                                             point(40.7636824529618, -73.98049869574606),
+                                                             point(40.76962974853814, -73.97964206524193),
+                                                             point(40.75981395319104, -73.98302106186748)),
+                                                     polygon(point(28.326568258926272, -81.60542246885598),
+                                                             point(28.327541397884488, -81.6022228449583),
+                                                             point(28.32950334995985, -81.60564735531807),
+                                                             point(28.326568258926272, -81.60542246885598))));
+        getDs().save(usa);
+
+        AllTheThings london = new AllTheThings("London", geometryCollection(
+                point(53.4722454, -2.2235922),
+                lineString(point(51.507780365645885, -0.21786745637655258),
+                           point(51.50802478194237, -0.21474729292094707),
+                           point(51.5086863655597, -0.20895397290587425)),
+                polygon(point(51.498216362670064, 0.0074849557131528854),
+                        point(51.49176875129342, 0.01821178011596203),
+                        point(51.492886897176504, 0.05523204803466797),
+                        point(51.49393044412136, 0.06663135252892971),
+                        point(51.498216362670064, 0.0074849557131528854))));
+        getDs().save(london);
+        getDs().ensureIndexes();
+
+        // when
+        List<AllTheThings> everythingInTheUK = getDs().find(AllTheThings.class)
+                                                      .field("everything")
+                                                      .intersects(polygon(point(37.4056048, -5.9666089),
+                                                                          point(37.404497, -5.9640557),
+                                                                          point(37.407239, -5.962988),
+                                                                          point(37.4056048, -5.9666089)))
+                                                      .asList();
+
+        // then
+        assertThat(everythingInTheUK.size(), is(1));
+        assertThat(everythingInTheUK.get(0), is(sevilla));
+    }
+
+}


### PR DESCRIPTION
Added the API for geoIntersects.  Unlike geoWithin, this method can take any geometry object, so there's only a single method rather than a series of overloaded methods with allowed types.

I've added tests for the basic types (point, line and polygon) to show how the feature works. Technically these "test" the server, but they do show the feature working with the major geometry types.