### PR TITLE
Fixed cause of null pointers when passing interfaces into getParameterizedClass

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/utils/ReflectionUtils.java
+++ b/morphia/src/main/java/org/mongodb/morphia/utils/ReflectionUtils.java
@@ -299,7 +299,13 @@ public final class ReflectionUtils {
                 return null;
             }
         } else {
-            final Type superclass = c.getGenericSuperclass();
+            Type superclass = c.getGenericSuperclass();
+            if (superclass == null && c.isInterface()) {
+                Type[] interfaces = c.getGenericInterfaces();
+                if (interfaces.length > 0) {
+                    superclass = interfaces[index];
+                }
+            }
             if (superclass instanceof ParameterizedType) {
                 final Type[] actualTypeArguments = ((ParameterizedType) superclass).getActualTypeArguments();
                 return actualTypeArguments.length > index ? (Class<?>) actualTypeArguments[index] : null;

--- a/morphia/src/test/java/org/mongodb/morphia/utils/ReflectionUtilsTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/utils/ReflectionUtilsTest.java
@@ -1,6 +1,5 @@
 package org.mongodb.morphia.utils;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mongodb.morphia.TestBase;
 import org.mongodb.morphia.annotations.Entity;
@@ -16,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.isA;
@@ -31,9 +31,8 @@ import static org.mongodb.morphia.testutil.ExactClassMatcher.exactClass;
 public class ReflectionUtilsTest extends TestBase {
 
     @Test
-    @Ignore("Not implemented yet")
-    public void shouldAcceptInterfacesWithoutGenericParameters() {
-        Class parameterizedClass = ReflectionUtils.getParameterizedClass(InterfaceWithoutGenericTypes.class);
+    public void shouldAcceptMapWithoutItsOwnGenericParameters() {
+        Class parameterizedClass = ReflectionUtils.getParameterizedClass(MapWithoutGenericTypes.class);
 
         assertThat(parameterizedClass, is(exactClass(Integer.class)));
     }
@@ -107,7 +106,7 @@ public class ReflectionUtilsTest extends TestBase {
         assertThat(ReflectionUtils.getClassEntityAnnotation(Fooble.class).value(), is(Mapper.IGNORED_FIELDNAME));
     }
 
-    private interface InterfaceWithoutGenericTypes extends List<Integer> {
+    private interface MapWithoutGenericTypes extends Map<Integer, String> {
     }
 
     @Entity("generic_arrays")


### PR DESCRIPTION
Changed getParameterizedClass so that if it's passed an interface without generic params that extends an interface with generic params, it will return the super-interface's generic param. Fixes #784.
Limitations: if passed an interface that extends more than one interface with generic params, will return the first only.