### PR TITLE
Fixed 839

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/GeoNear.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/GeoNear.java
@@ -268,7 +268,7 @@ public final class GeoNear {
          * @return this
          */
         public GeoNearBuilder setNear(final double latitude, final double longitude) {
-            this.near = new double[]{latitude, longitude};
+            this.near = new double[]{longitude, latitude};
             return this;
         }
 

--- a/morphia/src/test/java/org/mongodb/morphia/geo/PlaceWithLegacyCoords.java
+++ b/morphia/src/test/java/org/mongodb/morphia/geo/PlaceWithLegacyCoords.java
@@ -8,14 +8,14 @@ import org.mongodb.morphia.utils.IndexDirection;
 import java.util.Arrays;
 
 @SuppressWarnings("unused")
-class PlaceWithLegacyCoords {
+public class PlaceWithLegacyCoords {
     @Id
     private ObjectId id;
     @Indexed(IndexDirection.GEO2D)
     private double[] location = new double[2];
     private String name;
 
-    PlaceWithLegacyCoords(final double[] location, final String name) {
+    public PlaceWithLegacyCoords(final double[] location, final String name) {
         this.location = location;
         this.name = name;
     }


### PR DESCRIPTION
Swapped order of latitude and longitude in geoNear query (affects aggregation only, not geo queries). Fixes #839.  Added tests for both spherical and non-spherical queries.

Note: this will break any code that currently uses the geoNear aggregation query, existing code may have been compensating for the problem by swapping the params.