### PR TITLE
hasThisElement() - Add ability to use $not and limit field comparison for $elemMatch queries

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/GeoNear.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/GeoNear.java
@@ -154,12 +154,12 @@ public final class GeoNear {
     }
 
     /**
-     * If this value is true, the query returns a matching document once, even if more than one of the document’s location fields match the
-     * query.
+     * If this value is true, the query returns a matching document once, even if more than one of the document’s location fields match
+     * the query.
      *
      * @return true if returning only unique documents
-     * @deprecated since version MongoDB 2.6: Geospatial queries no longer return duplicate results. The $uniqueDocs operator has no impact
-     * on results.
+     * @deprecated since version MongoDB 2.6: Geospatial queries no longer return duplicate results. The $uniqueDocs operator has no
+     * impact on results.
      */
     @Deprecated
     public Boolean getUniqueDocuments() {

--- a/morphia/src/main/java/org/mongodb/morphia/aggregation/Sort.java
+++ b/morphia/src/main/java/org/mongodb/morphia/aggregation/Sort.java
@@ -35,6 +35,16 @@ public class Sort {
     }
 
     /**
+     * Creates a descending sort on a field
+     *
+     * @param field the field
+     * @return the Sort instance
+     */
+    public static Sort descending(final String field) {
+        return new Sort(field, -1);
+    }
+
+    /**
      * @return the sort direction
      */
     public int getDirection() {

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldCriteria.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldCriteria.java
@@ -11,7 +11,11 @@ import org.mongodb.morphia.mapping.MappedField;
 import org.mongodb.morphia.mapping.Mapper;
 import org.mongodb.morphia.utils.ReflectionUtils;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.mongodb.morphia.query.QueryValidator.validateQuery;
 
@@ -76,47 +80,46 @@ public class FieldCriteria extends AbstractCriteria {
             && !type.isArray() && !Iterable.class.isAssignableFrom(type)) {
             mappedValue = Collections.singletonList(mappedValue);
         }
+
         if (value != null && type == null && (op == FilterOperator.IN || op == FilterOperator.NOT_IN)
             && Iterable.class.isAssignableFrom(value.getClass())) {
             mappedValue = Collections.emptyList();
         }
 
         if (op == FilterOperator.ELEMENT_MATCH && mappedValue instanceof DBObject && !(mappedValue instanceof BasicDBList)) {
-            if(fieldsToCompare == null || fieldsToCompare.size() == 0) {
+            if (fieldsToCompare == null || fieldsToCompare.size() == 0) {
                 removeIdFieldFromComparison((DBObject) mappedValue, Mapper.ID_KEY);
-            }
-            else {
+            } else {
                 limitComparisonToSelectedFields(fieldsToCompare, (DBObject) mappedValue);
             }
         }
 
         this.field = sb.toString();
-        operator = op;
+        this.operator = op;
         this.value = mappedValue;
         this.not = not;
     }
 
-    private void removeIdFieldFromComparison(DBObject mappedValue, String idKey) {
+    private void removeIdFieldFromComparison(final DBObject mappedValue, final String idKey) {
         mappedValue.removeField(idKey);
     }
 
-    private void limitComparisonToSelectedFields(Set<String> fieldsToCompare, DBObject mappedValue) {
+    private void limitComparisonToSelectedFields(final Set<String> fieldsToCompare, final DBObject mappedValue) {
         HashSet<String> fields = extractFieldsAsHashSet(mappedValue);
         removeFields(mappedValue, fields, fieldsToCompare);
     }
 
-    private void removeFields(DBObject mappedValue, Set<String> allFields, Set<String> fieldsToCompare) {
-        for(String field : allFields)
-        {
-            if(!fieldsToCompare.contains(field)) {
+    private void removeFields(final DBObject mappedValue, final Set<String> allFields, final Set<String> fieldsToCompare) {
+        for (String field : allFields) {
+            if (!fieldsToCompare.contains(field)) {
                 mappedValue.removeField(field);
             }
         }
     }
 
-    private HashSet<String> extractFieldsAsHashSet(DBObject mappedValue) {
+    private HashSet<String> extractFieldsAsHashSet(final DBObject mappedValue) {
         HashSet<String> fields = new HashSet<String>();
-        for(String field : mappedValue.keySet()) {
+        for (String field : mappedValue.keySet()) {
             fields.add(field);
         }
         return fields;

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -7,9 +7,6 @@ import org.mongodb.morphia.geo.MultiPolygon;
 import org.mongodb.morphia.geo.Point;
 import org.mongodb.morphia.geo.Polygon;
 
-import java.util.HashSet;
-import java.util.Set;
-
 /**
  * Represents a document field in a query and presents the operations available to querying against that field.
  *

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -7,6 +7,9 @@ import org.mongodb.morphia.geo.MultiPolygon;
 import org.mongodb.morphia.geo.Point;
 import org.mongodb.morphia.geo.Polygon;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Represents a document field in a query and presents the operations available to querying against that field.
  *
@@ -137,6 +140,37 @@ public interface FieldEnd<T> {
      * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
      */
     T hasThisElement(Object val);
+
+    /**
+     * Checks that a field has the value listed.
+     *
+     * @param val the value to check against
+     * @param fieldsToCompare a list of the fields in the val parameter to compare against the sub-document
+     * @return T
+     * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
+     */
+    T hasThisElement(Object val, String... fieldsToCompare);
+
+    /**
+     * Checks that a field has the value listed.
+     *
+     * @param val the value to check against
+     * @param not set to true if the check should be negative
+     * @return T
+     * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
+     */
+    T hasThisElement(Object val, boolean not);
+
+    /**
+     * Checks that a field has the value listed.
+     *
+     * @param val the value to check against
+     * @param not set to true if the check should be negative
+     * @param fieldsToCompare a list of the fields in the val parameter to compare against the sub-document
+     * @return T
+     * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
+     */
+    T hasThisElement(Object val, boolean not, String... fieldsToCompare);
 
     /**
      * Checks that a field has the value listed.

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -10,7 +10,11 @@ import org.mongodb.morphia.logging.Logger;
 import org.mongodb.morphia.logging.MorphiaLoggerFactory;
 import org.mongodb.morphia.utils.Assert;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import static org.mongodb.morphia.query.FilterOperator.GEO_WITHIN;
@@ -39,7 +43,6 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
      * @param validateName true if the field name should be validated
      */
     public FieldEndImpl(final QueryImpl<?> query, final String field, final T target, final boolean validateName) {
-
         this(query, field, target, validateName, false);
     }
 
@@ -139,21 +142,21 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
     }
 
     @Override
-    public T hasThisElement(final Object val, boolean not) {
+    public T hasThisElement(final Object val, final boolean not) {
         Assert.parametersNotNull("val", val);
         return addCriteria(FilterOperator.ELEMENT_MATCH, val, not, null);
     }
 
     @Override
-    public T hasThisElement(final Object val, String... fieldsToCompare) {
-        Assert.parametersNotNull("fieldsToCompare", (Object[])fieldsToCompare);
+    public T hasThisElement(final Object val, final String... fieldsToCompare) {
+        Assert.parametersNotNull("fieldsToCompare", (Object[]) fieldsToCompare);
         return hasThisElement(val, false, fieldsToCompare);
     }
 
     @Override
-    public T hasThisElement(final Object val, boolean not, String... fieldsToCompare) {
+    public T hasThisElement(final Object val, final boolean not, final String... fieldsToCompare) {
         Assert.parametersNotNull("val", val);
-        Assert.parametersNotNull("fieldsToCompare", (Object[])fieldsToCompare);
+        Assert.parametersNotNull("fieldsToCompare", (Object[]) fieldsToCompare);
         return addCriteria(FilterOperator.ELEMENT_MATCH, val, not, new HashSet<String>(Arrays.asList(fieldsToCompare)));
     }
 
@@ -299,10 +302,10 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
     }
 
     private T addCriteria(final FilterOperator op, final Object val) {
-        return addCriteria(op, val, false, new HashSet<String>());
+        return addCriteria(op, val, not, new HashSet<String>());
     }
 
-    private T addCriteria(final FilterOperator op, final Object val, Boolean not, Set<String> fieldsToCompare) {
+    private T addCriteria(final FilterOperator op, final Object val, final boolean not, final Set<String> fieldsToCompare) {
         target.add(new FieldCriteria(query, field, op, val, validateName, query.isValidatingTypes(), not, fieldsToCompare));
         return target;
     }

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -10,8 +10,7 @@ import org.mongodb.morphia.logging.Logger;
 import org.mongodb.morphia.logging.MorphiaLoggerFactory;
 import org.mongodb.morphia.utils.Assert;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import static org.mongodb.morphia.query.FilterOperator.GEO_WITHIN;
@@ -136,8 +135,26 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
 
     @Override
     public T hasThisElement(final Object val) {
+        return hasThisElement(val, false);
+    }
+
+    @Override
+    public T hasThisElement(final Object val, boolean not) {
         Assert.parametersNotNull("val", val);
-        return addCriteria(FilterOperator.ELEMENT_MATCH, val);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, val, not, null);
+    }
+
+    @Override
+    public T hasThisElement(final Object val, String... fieldsToCompare) {
+        Assert.parametersNotNull("fieldsToCompare", (Object[])fieldsToCompare);
+        return hasThisElement(val, false, fieldsToCompare);
+    }
+
+    @Override
+    public T hasThisElement(final Object val, boolean not, String... fieldsToCompare) {
+        Assert.parametersNotNull("val", val);
+        Assert.parametersNotNull("fieldsToCompare", (Object[])fieldsToCompare);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, val, not, new HashSet<String>(Arrays.asList(fieldsToCompare)));
     }
 
     @Override
@@ -281,11 +298,12 @@ public class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T
         return target;
     }
 
-    /**
-     * Add a criteria
-     */
     private T addCriteria(final FilterOperator op, final Object val) {
-        target.add(new FieldCriteria(query, field, op, val, validateName, query.isValidatingTypes(), not));
+        return addCriteria(op, val, false, new HashSet<String>());
+    }
+
+    private T addCriteria(final FilterOperator op, final Object val, Boolean not, Set<String> fieldsToCompare) {
+        target.add(new FieldCriteria(query, field, op, val, validateName, query.isValidatingTypes(), not, fieldsToCompare));
         return target;
     }
 

--- a/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
@@ -368,7 +368,7 @@ public class TestQuery extends TestBase {
         assertNull(pwkBad);
     }
 
-    public static <E> List<E> makeArrayList(Iterable<E> iter) {
+    public static <E> List<E> makeArrayList(final Iterable<E> iter) {
         ArrayList<E> list = new ArrayList<E>();
         for (E item : iter) {
             list.add(item);
@@ -385,9 +385,9 @@ public class TestQuery extends TestBase {
         Iterable<Key<PhotoWithKeywords>> savedKeysResult = getDs().save(pwk1, pwk2, pwk3);
 
         List<Key<PhotoWithKeywords>> savedKeys = makeArrayList(savedKeysResult);
-        pwk1.id = (ObjectId)savedKeys.get(0).getId();
-        pwk2.id = (ObjectId)savedKeys.get(1).getId();
-        pwk3.id = (ObjectId)savedKeys.get(2).getId();
+        pwk1.id = (ObjectId) savedKeys.get(0).getId();
+        pwk2.id = (ObjectId) savedKeys.get(1).getId();
+        pwk3.id = (ObjectId) savedKeys.get(2).getId();
 
         Query<PhotoWithKeywords> query = getDs().find(PhotoWithKeywords.class)
                 .field("keywords")
@@ -401,7 +401,7 @@ public class TestQuery extends TestBase {
         boolean pwk2Found = false;
         boolean pwk3Found = false;
 
-        for(PhotoWithKeywords p : results) {
+        for (PhotoWithKeywords p : results) {
             if (p.id.equals(pwk1.id)) {
                 pwk1Found = true;
             }

--- a/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
@@ -366,7 +366,84 @@ public class TestQuery extends TestBase {
         //        assertNotNull(pwkScottSarah);
         final PhotoWithKeywords pwkBad = getDs().find(PhotoWithKeywords.class).field("keywords").hasThisElement(new Keyword("Randy")).get();
         assertNull(pwkBad);
+    }
 
+    public static <E> List<E> makeArrayList(Iterable<E> iter) {
+        ArrayList<E> list = new ArrayList<E>();
+        for (E item : iter) {
+            list.add(item);
+        }
+        return list;
+    }
+
+    @Test
+    public void testElemMatchQueryCanBeNegated() throws Exception {
+        final PhotoWithKeywords pwk1 = new PhotoWithKeywords();
+        final PhotoWithKeywords pwk2 = new PhotoWithKeywords("Kevin");
+        final PhotoWithKeywords pwk3 = new PhotoWithKeywords("Scott", "Joe", "Sarah");
+
+        Iterable<Key<PhotoWithKeywords>> savedKeysResult = getDs().save(pwk1, pwk2, pwk3);
+
+        List<Key<PhotoWithKeywords>> savedKeys = makeArrayList(savedKeysResult);
+        pwk1.id = (ObjectId)savedKeys.get(0).getId();
+        pwk2.id = (ObjectId)savedKeys.get(1).getId();
+        pwk3.id = (ObjectId)savedKeys.get(2).getId();
+
+        Query<PhotoWithKeywords> query = getDs().find(PhotoWithKeywords.class)
+                .field("keywords")
+                .hasThisElement(new Keyword("Scott"), true);
+        List<PhotoWithKeywords> results = query.asList();
+
+        assertThat("2 results should be returned because pwk1 doesn't have any keywords, and pwk2 doesn't have a keyword with Scott in it.",
+                results.size(), is(2));
+
+        boolean pwk1Found = false;
+        boolean pwk2Found = false;
+        boolean pwk3Found = false;
+
+        for(PhotoWithKeywords p : results) {
+            if (p.id.equals(pwk1.id)) {
+                pwk1Found = true;
+            }
+
+            if (p.id.equals(pwk2.id)) {
+                pwk2Found = true;
+            }
+
+            if (p.id.equals(pwk3.id)) {
+                pwk3Found = true;
+            }
+        }
+
+        assertThat("The first record was found, because it doesn't have any keywords.", pwk1Found, is(true));
+        assertThat("The second record was found, because it doesn't have a matching keyword.", pwk2Found, is(true));
+        assertThat("The third record was not found, because it has matching keyword.", pwk3Found, is(false));
+    }
+
+    @Test
+    public void testThatElemMatchQueriesOnlyChecksRequiredFields() throws Exception {
+        final PhotoWithKeywords pwk1 = new PhotoWithKeywords();
+        final PhotoWithKeywords pwk2 = new PhotoWithKeywords("Joe", "Sarah");
+        pwk2.keywords.add(new Keyword("Scott", 14));
+
+        getDs().save(pwk1, pwk2);
+
+        // In this case, we only want to match on the keyword field, not the
+        // score field, which shouldn't be included in the elemMatch query.
+
+        // As a result, the query in MongoDB should look like:
+        // find({ keywords: { $elemMatch: { keyword: "Scott" } } })
+
+        // NOT:
+        // find({ keywords: { $elemMatch: { keyword: "Scott", score: 12 } } })
+        Query<PhotoWithKeywords> query = getDs().find(PhotoWithKeywords.class)
+                .field("keywords")
+                .hasThisElement(new Keyword("Scott"), "keyword");
+        final PhotoWithKeywords pwkScott = query.get();
+        assertNotNull(pwkScott);
+
+        final PhotoWithKeywords pwkBad = getDs().find(PhotoWithKeywords.class).field("keywords").hasThisElement(new Keyword("Randy")).get();
+        assertNull(pwkBad);
     }
 
     @Test
@@ -1029,7 +1106,12 @@ public class TestQuery extends TestBase {
         }
 
         public Keyword(final String k) {
-            keyword = k;
+            this.keyword = k;
+        }
+
+        public Keyword(final String k, final int score) {
+            this.keyword = k;
+            this.score = score;
         }
     }
 

--- a/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
@@ -159,9 +159,14 @@ public class AggregationTest extends TestBase {
                                                        .build();
         Iterator<Author> aggregate = getDs().createAggregation(Book.class)
                                             .group("author", grouping("books", push("title")))
+                                            .sort(Sort.ascending("author"))
                                             .out(Author.class, options);
         Assert.assertEquals(2, getDs().getCollection(Author.class).count());
         Author author = aggregate.next();
+        Assert.assertEquals("Dante", author.name);
+        Assert.assertEquals(asList("The Banquet", "Divine Comedy", "Eclogues"), author.books);
+
+        author = aggregate.next();
         Assert.assertEquals("Homer", author.name);
         Assert.assertEquals(asList("The Odyssey", "Iliad"), author.books);
 


### PR DESCRIPTION
Created to resolve issues #905 and #906.

- The $elemMatch operator cannot be negated
- The $elemMatch operator matches against all fields within the class

I was unable to use Morphia to push a value into an array of embedded documents if the embedded document was missing. This was due to encountering the lack of a $not capability in the hasThisElement filter and the fact that the hasThisElement filter creates a query which compares all values in the val parameter against the MongoDB document.

This pull request creates the ability to negate the hasThisElement method and limit the fields which are compared.