### PR TITLE
Added @IdGetter annotation for method that returns the ID. Use it to optimize lazy loading

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/annotations/IdGetter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/annotations/IdGetter.java
@@ -8,6 +8,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * This annotation allows the lazy-load proxy to return the ID of a referenced entity without reading the reference from the database.
+ */
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)

--- a/morphia/src/main/java/org/mongodb/morphia/annotations/IdGetter.java
+++ b/morphia/src/main/java/org/mongodb/morphia/annotations/IdGetter.java
@@ -1,0 +1,17 @@
+package org.mongodb.morphia.annotations;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface IdGetter {
+
+}

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/NonFinalizingHotSwappingInvoker.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/NonFinalizingHotSwappingInvoker.java
@@ -6,6 +6,9 @@ import com.thoughtworks.proxy.kit.ObjectReference;
 import com.thoughtworks.proxy.toys.delegate.DelegationMode;
 import com.thoughtworks.proxy.toys.hotswap.HotSwappingInvoker;
 
+import org.mongodb.morphia.mapping.lazy.proxy.EntityObjectReference;
+import org.mongodb.morphia.annotations.IdGetter;
+
 import java.lang.reflect.Method;
 
 
@@ -23,6 +26,19 @@ class NonFinalizingHotSwappingInvoker<T> extends HotSwappingInvoker<T> {
     public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable {
         if ("finalize".equals(method.getName()) && args != null && args.length == 0) {
             return null;
+        }
+
+        /*
+         * If the method being invoked is annotated with @IdGetter and the delegate reference is an EntityObjectReference,
+         * return the id of the EntityObjectReference's key. This allows us to return the referenced entity's id without
+         * fetching the entity from the datastore.
+         */
+        if (method.getAnnotation(IdGetter.class) != null) {
+            ObjectReference<Object> delegateReference = getDelegateReference();
+            if (delegateReference instanceof EntityObjectReference) {
+                EntityObjectReference entityObjectReference = (EntityObjectReference)delegateReference;
+                return entityObjectReference.__getKey().getId();
+            }
         }
 
         return super.invoke(proxy, method, args);

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/NonFinalizingHotSwappingInvoker.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/lazy/NonFinalizingHotSwappingInvoker.java
@@ -36,7 +36,7 @@ class NonFinalizingHotSwappingInvoker<T> extends HotSwappingInvoker<T> {
         if (method.getAnnotation(IdGetter.class) != null) {
             ObjectReference<Object> delegateReference = getDelegateReference();
             if (delegateReference instanceof EntityObjectReference) {
-                EntityObjectReference entityObjectReference = (EntityObjectReference)delegateReference;
+                EntityObjectReference entityObjectReference = (EntityObjectReference) delegateReference;
                 return entityObjectReference.__getKey().getId();
             }
         }


### PR DESCRIPTION
Say an entity contains a lazy-load reference to another entity. The application has read the first entity from the database and now it wants to retrieve the ID of the 2nd entity - just the ID. In this case, there is no need for the lazy-load proxy to read the whole 2nd entity from the database, since the ID is already contained in the first entity - hidden inside the lazy load proxy.

This optimization is very useful when building a RESTful webservice whose GET replies contain hyperlinks. When I implement the GET on the first entity, to build the hyperlink to the 2nd entity I only need the 2nd entity's ID. I can avoid the unnecessary database read, I can avoid an N+1 SELECT kind of issue.