### PR TITLE
#870: ensureIndexes() throws unhandleable "Index with name: xyz_1" already exists

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -12,10 +12,13 @@ import com.mongodb.DefaultDBDecoder;
 import com.mongodb.MapReduceCommand;
 import com.mongodb.MapReduceCommand.OutputType;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
 import org.mongodb.morphia.aggregation.AggregationPipeline;
 import org.mongodb.morphia.aggregation.AggregationPipelineImpl;
 import org.mongodb.morphia.annotations.CappedAt;
@@ -259,7 +262,8 @@ public class DatastoreImpl implements AdvancedDatastore {
     public <T> void ensureIndex(final Class<T> clazz, final String name, final String fields, final boolean unique,
                                 final boolean dropDupsOnCreate) {
         ensureIndex(clazz, name, parseFieldsString(fields, clazz, mapper, true, Collections.<MappedClass>emptyList(),
-                                                   Collections.<MappedField>emptyList()), unique, dropDupsOnCreate, false, false, -1);
+                                                   Collections.<MappedField>emptyList()), unique, dropDupsOnCreate,
+                                                   false, false, -1, false);
     }
 
     @Override
@@ -844,7 +848,7 @@ public class DatastoreImpl implements AdvancedDatastore {
                                 final boolean dropDupsOnCreate) {
         ensureIndex(getCollection(collection), name,
                     parseFieldsString(fields, clazz, mapper, true, Collections.<MappedClass>emptyList(),
-                                      Collections.<MappedField>emptyList()), unique, dropDupsOnCreate, false, false, -1);
+                                      Collections.<MappedField>emptyList()), unique, dropDupsOnCreate, false, false, -1, false);
     }
 
     @Override
@@ -1066,14 +1070,14 @@ public class DatastoreImpl implements AdvancedDatastore {
 
     protected <T> void ensureIndex(final Class<T> clazz, final String name, final BasicDBObject fields, final boolean unique,
                                    final boolean dropDupsOnCreate, final boolean background, final boolean sparse,
-                                   final int expireAfterSeconds) {
+                                   final int expireAfterSeconds, final boolean dropOutdated) {
         final DBCollection dbColl = getCollection(clazz);
-        ensureIndex(dbColl, name, fields, unique, dropDupsOnCreate, background, sparse, expireAfterSeconds);
+        ensureIndex(dbColl, name, fields, unique, dropDupsOnCreate, background, sparse, expireAfterSeconds, dropOutdated);
     }
 
     protected void ensureIndex(final DBCollection dbColl, final String name, final BasicDBObject fields, final boolean unique,
                                final boolean dropDupsOnCreate, final boolean background, final boolean sparse,
-                               final int expireAfterSeconds) {
+                               final int expireAfterSeconds, final boolean dropOutdated) {
         final BasicDBObject opts = new BasicDBObject();
         if (name != null && name.length() != 0) {
             opts.append("name", name);
@@ -1095,9 +1099,12 @@ public class DatastoreImpl implements AdvancedDatastore {
         if (expireAfterSeconds > -1) {
             opts.append("expireAfterSeconds", expireAfterSeconds);
         }
+        if (dropOutdated) {
+            opts.append("dropOutdated", true);
+        }
 
         LOG.debug(format("Creating index for %s with keys:%s and opts:%s", dbColl.getName(), fields, opts));
-        dbColl.createIndex(fields, opts);
+        createMongoIndex(dbColl, fields, opts);
     }
 
     protected void ensureIndex(final MappedClass mc, final DBCollection dbColl, final Field[] fields, final IndexOptions options,
@@ -1144,12 +1151,37 @@ public class DatastoreImpl implements AdvancedDatastore {
         }
 
         LOG.debug(format("Creating index for %s with keys:%s and opts:%s", dbColl.getName(), keys, opts));
-        dbColl.createIndex(keys, opts);
+        createMongoIndex(dbColl, keys, opts);
     }
 
-    protected void ensureIndex(final DBCollection dbColl, final DBObject keys, final DBObject options) {
+    protected void ensureIndex(final DBCollection dbColl, final DBObject keys, final BasicDBObject options) {
         LOG.debug(format("Creating index for %s with keys:%s and opts:%s", dbColl.getName(), keys, options));
-        dbColl.createIndex(keys, options);
+        createMongoIndex(dbColl, keys, options);
+    }
+
+    private void createMongoIndex(final DBCollection dbColl, final DBObject keys, final DBObject options) {
+        try {
+            dbColl.createIndex(keys, options);
+        } catch (MongoCommandException ex) {
+            final BasicDBObject basicOptions = (BasicDBObject) options;
+            if (basicOptions.getBoolean("dropOutdated", false)) {
+                final BsonDocument errorDocument = ex.getResponse();
+                if (errorDocument.getInt32("code").intValue() == 85) {
+                    String indexName;
+                    if (options.containsKey("name")) {
+                        indexName = basicOptions.getString("name");
+                    } else {
+                        final BsonString errorMessage = errorDocument.getString("errmsg");
+                        final String[] errorSplit = errorMessage.getValue().split("\\s");
+                        indexName = errorSplit[3];
+                    }
+                    dbColl.dropIndex(indexName);
+                    dbColl.createIndex(keys, options);
+                    return;
+                }
+            }
+            throw ex;
+        }
     }
 
     protected void ensureIndexes(final MappedClass mc, final boolean background, final List<MappedClass> parentMCs,
@@ -1315,7 +1347,7 @@ public class DatastoreImpl implements AdvancedDatastore {
             weights.put(field, index.value());
         }
         LOG.debug(format("Creating index for %s with keys:%s and opts:%s", dbColl.getName(), keys, opts));
-        dbColl.createIndex(keys, opts);
+        createMongoIndex(dbColl, keys, opts);
     }
 
     private DBObject entityToDBObj(final Object entity, final Map<Object, DBObject> involvedObjects) {
@@ -1332,6 +1364,7 @@ public class DatastoreImpl implements AdvancedDatastore {
         putIfTrue(opts, "dropDups", options.dropDups());
         putIfTrue(opts, "sparse", options.sparse());
         putIfTrue(opts, "unique", options.unique());
+        putIfTrue(opts, "dropOutdated", options.dropOutdated());
         if (options.expireAfterSeconds() != -1) {
             opts.put("expireAfterSeconds", options.expireAfterSeconds());
         }
@@ -1474,7 +1507,8 @@ public class DatastoreImpl implements AdvancedDatastore {
                             final BasicDBObject fields = parseFieldsString(index.value(), mc.getClazz(), mapper,
                                                                            !index.disableValidation(), parentMCs, parentMFs);
                             ensureIndex(dbColl, index.name(), fields, index.unique(), index.dropDups(),
-                                        index.background() ? index.background() : background, index.sparse(), index.expireAfterSeconds());
+                                        index.background() ? index.background() : background, index.sparse(), index.expireAfterSeconds(),
+                                        false);
                         }
                     }
                 }
@@ -1518,7 +1552,8 @@ public class DatastoreImpl implements AdvancedDatastore {
                                 index.dropDups(),
                                 index.background() || background,
                                 index.sparse(),
-                                index.expireAfterSeconds());
+                                index.expireAfterSeconds(),
+                                false);
                 }
             }
 

--- a/morphia/src/main/java/org/mongodb/morphia/annotations/IndexOptions.java
+++ b/morphia/src/main/java/org/mongodb/morphia/annotations/IndexOptions.java
@@ -78,4 +78,9 @@ public @interface IndexOptions {
      * Creates the index as a unique value index; inserting duplicates values in this field will cause errors
      */
     boolean unique() default false;
+
+    /**
+     * Removes an existing index, if the options of the existing index with the same name have changed.
+     */
+    boolean dropOutdated() default false;
 }

--- a/morphia/src/main/java/org/mongodb/morphia/annotations/IndexOptions.java
+++ b/morphia/src/main/java/org/mongodb/morphia/annotations/IndexOptions.java
@@ -80,7 +80,9 @@ public @interface IndexOptions {
     boolean unique() default false;
 
     /**
-     * Removes an existing index, if the options of the existing index with the same name have changed.
+     * Removes an existing index, if the options of the existing index with the same name has changed.
+     *
+     * This option can be used with MongoDB-server version 2.6 and above.
      */
     boolean dropOutdated() default false;
 }

--- a/morphia/src/test/java/org/mongodb/morphia/indexes/TestIndexOptionAsDropOutdated.java
+++ b/morphia/src/test/java/org/mongodb/morphia/indexes/TestIndexOptionAsDropOutdated.java
@@ -1,0 +1,127 @@
+package org.mongodb.morphia.indexes;
+
+import com.mongodb.MongoCommandException;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.mongodb.morphia.TestBase;
+import org.mongodb.morphia.annotations.Entity;
+import org.mongodb.morphia.annotations.Field;
+import org.mongodb.morphia.annotations.Id;
+import org.mongodb.morphia.annotations.Index;
+import org.mongodb.morphia.annotations.IndexOptions;
+import org.mongodb.morphia.annotations.Indexed;
+import org.mongodb.morphia.annotations.Indexes;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Ulrich Cech
+ */
+@SuppressWarnings("unused")
+public class TestIndexOptionAsDropOutdated extends TestBase {
+
+    @Test
+    public void testDropOutdatedIndexWhenOptionsHaveChangedWithUnnamedIndex() {
+        executeTest(EnsureIndexWithDropOutdatedIndex1.class,
+                    EnsureIndexWithDropOutdatedIndex2.class,
+                    EnsureIndexWithDropOutdatedIndex3.class);
+    }
+
+    @Test
+    public void testDropOutdatedIndexWhenOptionsHaveChangedWithNamedIndex() {
+        executeTest(EnsureIndexWithDropOutdatedIndex4.class,
+                    EnsureIndexWithDropOutdatedIndex5.class,
+                    EnsureIndexWithDropOutdatedIndex6.class);
+    }
+
+    @Test
+    public void testDropOutdatedIndexWhenOptionsHaveChangedWithClassIndex() {
+        executeTest(EnsureIndexWithDropOutdatedIndex7.class,
+                    EnsureIndexWithDropOutdatedIndex8.class,
+                    EnsureIndexWithDropOutdatedIndex9.class);
+    }
+
+    private void executeTest(final Class entityWithIndex, final Class entityWithDropOutdated, final Class entityWithoutDropOutdated) {
+        getMorphia().map(entityWithIndex);
+        getDs().ensureIndexes();
+        getMorphia().map(entityWithDropOutdated);
+        try {
+            getDs().ensureIndexes();
+        } catch (MongoCommandException ex) {
+            fail("Changed index should have been updated.");
+        }
+        getMorphia().map(entityWithoutDropOutdated);
+        try {
+            getDs().ensureIndexes();
+            fail("Should throw a MongoCommandException for existing index with different options.");
+        } catch (MongoCommandException ex) {
+            assertThat(ex.getMessage().startsWith("Command failed with error 85"), is(true));
+        }
+    }
+
+
+    private static class BaseEntity {
+        @Id
+        private ObjectId id;
+    }
+
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex1 extends BaseEntity {
+        @Indexed(options = @IndexOptions(unique = true))
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex2 extends BaseEntity {
+        @Indexed(options = @IndexOptions(dropOutdated = true))
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex3 extends BaseEntity {
+        @Indexed(options = @IndexOptions())
+        private long indexField;
+    }
+
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex4 extends BaseEntity {
+        @Indexed(options = @IndexOptions(name = "index1", unique = true))
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex5 extends BaseEntity {
+        @Indexed(options = @IndexOptions(name = "index1", dropOutdated = true))
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    private static class EnsureIndexWithDropOutdatedIndex6 extends BaseEntity {
+        @Indexed(options = @IndexOptions(name = "index1"))
+        private long indexField;
+    }
+
+
+    @Entity(value = "IndexCollection")
+    @Indexes(@Index(fields = @Field(value = "indexField"), options = @IndexOptions(unique = true)))
+    private static class EnsureIndexWithDropOutdatedIndex7 extends BaseEntity {
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    @Indexes(@Index(fields = @Field(value = "indexField"), options = @IndexOptions(dropOutdated = true)))
+    private static class EnsureIndexWithDropOutdatedIndex8 extends BaseEntity {
+        private long indexField;
+    }
+
+    @Entity(value = "IndexCollection")
+    @Indexes(@Index(fields = @Field(value = "indexField")))
+    private static class EnsureIndexWithDropOutdatedIndex9 extends BaseEntity {
+        private long indexField;
+    }
+
+}

--- a/morphia/src/test/java/org/mongodb/morphia/indexes/TestIndexOptionAsDropOutdated.java
+++ b/morphia/src/test/java/org/mongodb/morphia/indexes/TestIndexOptionAsDropOutdated.java
@@ -44,20 +44,22 @@ public class TestIndexOptionAsDropOutdated extends TestBase {
     }
 
     private void executeTest(final Class entityWithIndex, final Class entityWithDropOutdated, final Class entityWithoutDropOutdated) {
-        getMorphia().map(entityWithIndex);
-        getDs().ensureIndexes();
-        getMorphia().map(entityWithDropOutdated);
-        try {
+        if (serverIsAtLeastVersion(2.6)) {
+            getMorphia().map(entityWithIndex);
             getDs().ensureIndexes();
-        } catch (MongoCommandException ex) {
-            fail("Changed index should have been updated.");
-        }
-        getMorphia().map(entityWithoutDropOutdated);
-        try {
-            getDs().ensureIndexes();
-            fail("Should throw a MongoCommandException for existing index with different options.");
-        } catch (MongoCommandException ex) {
-            assertThat(ex.getMessage().startsWith("Command failed with error 85"), is(true));
+            getMorphia().map(entityWithDropOutdated);
+            try {
+                getDs().ensureIndexes();
+            } catch (MongoCommandException ex) {
+                fail("Changed index should have been updated.");
+            }
+            getMorphia().map(entityWithoutDropOutdated);
+            try {
+                getDs().ensureIndexes();
+                fail("Should throw a MongoCommandException for existing index with different options.");
+            } catch (MongoCommandException ex) {
+                assertThat(ex.getMessage().startsWith("Command failed with error 85"), is(true));
+            }
         }
     }
 


### PR DESCRIPTION
- added a new parameter to IndexOptions for controlling the recreation of the outdated index