### PR TITLE
$meta projection operator support in text search query

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/query/Meta.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/Meta.java
@@ -1,0 +1,78 @@
+package org.mongodb.morphia.query;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+
+/**
+ * Defines $meta expression object
+ * @mongodb.driver.manual reference/operator/aggregation/meta/ $meta
+ */
+public class Meta {
+
+    private static final String META = "$meta";
+
+    /**
+     * Representing specified metadata keyword
+     * @mongodb.driver.manual reference/operator/aggregation/meta/#exp._S_meta $meta
+     */
+    public enum MetaDataKeyword {
+        textScore;
+
+        /**
+         * @return MetaDataKeyword name
+         */
+        public String getName() {
+            return textScore.name();
+        }
+    }
+
+    private MetaDataKeyword metaDataKeyword;
+    private String field;
+
+    /**
+     * Specify the meta
+     * @param metaDataKeyword - metadata keyword to create
+     */
+    public Meta(final MetaDataKeyword metaDataKeyword) {
+        this.metaDataKeyword = metaDataKeyword;
+        this.field = metaDataKeyword.getName();
+    }
+
+    /**
+     * @param metaDataKeyword  - metadata keyword to create
+     * @param field - metadata object field name
+     */
+    public Meta(final MetaDataKeyword metaDataKeyword, final String field) {
+        this.metaDataKeyword = metaDataKeyword;
+        this.field = field;
+    }
+
+    /**
+     * @return metadata object field name
+     */
+    public String getField() {
+        return field;
+    }
+
+    /**
+     * factory method for textScore metaDataKeyword
+     * @return instance of 'textScore' Meta
+     */
+    public static Meta textScore() {
+        return new Meta(MetaDataKeyword.textScore);
+    }
+
+    /**
+     *
+     * @param field - the field to project meta data
+     * @return  instance of 'textScore' Meta
+     */
+    public static Meta textScore(final String field) {
+        return new Meta(MetaDataKeyword.textScore, field);
+    }
+
+    DBObject toDatabase() {
+        BasicDBObject metaObject = new BasicDBObject(META, metaDataKeyword.getName());
+        return new BasicDBObject(field, metaObject);
+    }
+}

--- a/morphia/src/main/java/org/mongodb/morphia/query/Query.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/Query.java
@@ -267,8 +267,8 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
     Query<T> order(String sort);
 
     /**
-     * Sorts based on a meta data (defines return order).  Examples:
-     *
+     * Sorts based on a metadata (defines return order). Example:
+     * {@code order(Meta.textScore())}  ({textScore : { $meta: "textScore" }})
      * @param sort the sort order to apply
      * @return this
      */
@@ -298,9 +298,9 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
     Query<T> project(String field, ArraySlice slice);
 
     /**
-     * Adds an meta field to a projection.
+     * Adds a metadata field to a projection.
      *
-     * @param meta the options for projecting
+     * @param meta the metadata option for projecting
      * @return this
      * @see <a href="https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/">Project Fields to Return from Query</a>
      * @mongodb.driver.manual reference/operator/aggregation/meta/ $meta

--- a/morphia/src/main/java/org/mongodb/morphia/query/Query.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/Query.java
@@ -267,6 +267,14 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
     Query<T> order(String sort);
 
     /**
+     * Sorts based on a meta data (defines return order).  Examples:
+     *
+     * @param sort the sort order to apply
+     * @return this
+     */
+    Query<T> order(Meta sort);
+
+    /**
      * Adds a field to the projection clause.  Passing true for include will include the field in the results.  Projected fields must all
      * be inclusions or exclusions.  You can not include and exclude fields at the same time with the exception of the _id field.  The
      * _id field is always included unless explicitly suppressed.
@@ -288,6 +296,16 @@ public interface Query<T> extends QueryResults<T>, Cloneable {
      * @mongodb.driver.manual /reference/operator/projection/slice/ $slice
      */
     Query<T> project(String field, ArraySlice slice);
+
+    /**
+     * Adds an meta field to a projection.
+     *
+     * @param meta the options for projecting
+     * @return this
+     * @see <a href="https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results/">Project Fields to Return from Query</a>
+     * @mongodb.driver.manual reference/operator/aggregation/meta/ $meta
+     */
+    Query<T> project(Meta meta);
 
     /**
      * Route query to non-primary node

--- a/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
@@ -1,7 +1,12 @@
 package org.mongodb.morphia.query;
 
 
-import com.mongodb.*;
+import com.mongodb.BasicDBObject;
+import com.mongodb.Bytes;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.ReadPreference;
 import org.bson.BSONObject;
 import org.bson.types.CodeWScope;
 import org.mongodb.morphia.Datastore;


### PR DESCRIPTION
I'd like to propose the implementation of [$meta](https://docs.mongodb.com/manual/reference/operator/aggregation/meta/#exp._S_meta) projection for Query. I belive, the request is linked with issue #799
The request doesn't contains $meta projection operator support for AgregationPipline. I think it can be done later.