### PR TITLE
Fix typo (de)

### DIFF
--- a/docs/reference/content/guides/querying.md
+++ b/docs/reference/content/guides/querying.md
@@ -156,7 +156,7 @@ datastore.save(new Greeting("good riddance", "english"));
 
 datastore.save(new Greeting("guten Morgen", "german"));
 datastore.save(new Greeting("guten Tag", "german"));
-datastore.save(new Greeting("guten Nacht", "german"));
+datastore.save(new Greeting("gute Nacht", "german"));
 
 List<Greeting> good = datastore.createQuery(Greeting.class)
                              .search("good")

--- a/morphia/src/test/java/org/mongodb/morphia/query/TestTextSearching.java
+++ b/morphia/src/test/java/org/mongodb/morphia/query/TestTextSearching.java
@@ -33,7 +33,7 @@ public class TestTextSearching extends TestBase {
 
         getDs().save(new Greeting("guten Morgen", "german"));
         getDs().save(new Greeting("guten Tag", "german"));
-        getDs().save(new Greeting("guten Nacht", "german"));
+        getDs().save(new Greeting("gute Nacht", "german"));
 
         getDs().save(new Greeting("buenos días", "spanish"));
         getDs().save(new Greeting("buenas tardes", "spanish"));


### PR DESCRIPTION
Fix small typo:
- `guten Nacht` -> `gute Nacht`

http://www.duden.de/rechtschreibung/Nacht