### PR TITLE
new implementation of $elemMatch support

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -39,6 +39,8 @@ import org.mongodb.morphia.mapping.lazy.LazyFeatureDependencies;
 import org.mongodb.morphia.mapping.lazy.LazyProxyFactory;
 import org.mongodb.morphia.mapping.lazy.proxy.ProxiedEntityReference;
 import org.mongodb.morphia.mapping.lazy.proxy.ProxyHelper;
+import org.mongodb.morphia.query.Query;
+import org.mongodb.morphia.query.QueryImpl;
 import org.mongodb.morphia.query.ValidationException;
 
 import java.io.IOException;
@@ -584,10 +586,9 @@ public class Mapper {
     public Object toMongoObject(final MappedField mf, final MappedClass mc, final Object value) {
         Object mappedValue = value;
 
-       /* if (mf == null && mc != null && value != null) {
-            mappedValue = toMongoObject(mappedValue, false);
-        } else*/
-        if (isAssignable(mf, value) || isEntity(mc)) {
+        if (value instanceof Query) {
+            mappedValue = ((QueryImpl) value).getQueryObject();
+        } else if (isAssignable(mf, value) || isEntity(mc)) {
             //convert the value to Key (DBRef) if the field is @Reference or type is Key/DBRef, or if the destination class is an @Entity
             try {
                 if (value instanceof Iterable) {

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -138,10 +138,12 @@ public interface FieldEnd<T> {
      * @return T
      * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
      * @see MapperOptions
+     * @deprecated use {@link #elemMatch(Query)} instead
      */
+    @Deprecated
     T hasThisElement(Object val);
 
-//    T hasThisElement(Criteria... values);
+    T elemMatch(Query query);
 
     /**
      * Checks that a field does not have the value listed.  The options to store null/empty values apply here so to do partial matches on

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -143,6 +143,13 @@ public interface FieldEnd<T> {
     @Deprecated
     T hasThisElement(Object val);
 
+    /**
+     * Checks that a field matches the provided query definition
+     *
+     * @param query the query to find certain field values
+     * @return T
+     * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
+     */
     T elemMatch(Query query);
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -159,8 +159,10 @@ public interface FieldEnd<T> {
      * @param val the value to check against
      * @return T
      * @mongodb.driver.manual reference/operator/query/elemMatch/ $elemMatch
+     * @deprecated use {@link #elemMatch(Query)} instead
      * @see MapperOptions
      */
+    @Deprecated
     T doesNotHaveThisElement(Object val);
 
     /**

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEnd.java
@@ -141,6 +141,8 @@ public interface FieldEnd<T> {
      */
     T hasThisElement(Object val);
 
+//    T hasThisElement(Criteria... values);
+
     /**
      * Checks that a field does not have the value listed.  The options to store null/empty values apply here so to do partial matches on
      * embedded objects, pass a reference to a partially populated instance with only the values of interest set to the values to check.

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -142,7 +142,7 @@ class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T> {
     @Override
     public T hasThisElement(final Object val) {
         Assert.parametersNotNull("val", val);
-        return addCriteria(FilterOperator.ELEMENT_MATCH, val, not);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, val, false);
     }
 
     @Override

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -142,13 +142,13 @@ class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T> {
     @Override
     public T hasThisElement(final Object val) {
         Assert.parametersNotNull("val", val);
-        return addCriteria(FilterOperator.ELEMENT_MATCH, val, false);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, val, not);
     }
 
     @Override
     public T elemMatch(final Query query) {
         Assert.parametersNotNull("query", query);
-        return addCriteria(FilterOperator.ELEMENT_MATCH, query, false);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, query, not);
     }
 
     @Override

--- a/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/FieldEndImpl.java
@@ -146,6 +146,12 @@ class FieldEndImpl<T extends CriteriaContainerImpl> implements FieldEnd<T> {
     }
 
     @Override
+    public T elemMatch(final Query query) {
+        Assert.parametersNotNull("query", query);
+        return addCriteria(FilterOperator.ELEMENT_MATCH, query, false);
+    }
+
+    @Override
     public T hasThisOne(final Object val) {
         return addCriteria(FilterOperator.EQUAL, val);
     }

--- a/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/query/QueryImpl.java
@@ -728,7 +728,7 @@ public class QueryImpl<T> extends CriteriaContainerImpl implements Query<T> {
 
     @Override
     public String toString() {
-        return String.format("{ %s %s }", getQueryObject(), projections == null ? "" : ", " + getFieldsObject());
+        return String.format("{ query: %s %s }", getQueryObject(), projections == null ? "" : ", projection: " + getFieldsObject());
     }
 
     /**

--- a/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
@@ -381,7 +381,7 @@ public class TestQuery extends TestBase {
     }
 
     @Test
-    public void testElemMatchQueryCanBeNegated() {
+    public void testElemMatchVariants() {
         final PhotoWithKeywords pwk1 = new PhotoWithKeywords();
         final PhotoWithKeywords pwk2 = new PhotoWithKeywords("Kevin");
         final PhotoWithKeywords pwk3 = new PhotoWithKeywords("Scott", "Joe", "Sarah");
@@ -418,16 +418,16 @@ public class TestQuery extends TestBase {
                                                                 .asKeyList());
 
         validate(asList(key1, key2), asList(key3, key4), getDs().find(PhotoWithKeywords.class)
-                                                   .field("keywords")
-                                                   .doesNotHaveThisElement(new Keyword("Scott"))
-                                                   .asKeyList());
+                                                                .field("keywords")
+                                                                .doesNotHaveThisElement(new Keyword("Scott"))
+                                                                .asKeyList());
 
         validate(asList(key1, key2), asList(key3, key4), getDs().find(PhotoWithKeywords.class)
-                                                   .field("keywords").not()
-                                                   .elemMatch(getDs()
-                                                                  .createQuery(Keyword.class)
-                                                                  .field("keyword").equal("Scott"))
-                                                   .asKeyList());
+                                                                .field("keywords").not()
+                                                                .elemMatch(getDs()
+                                                                               .createQuery(Keyword.class)
+                                                                               .field("keyword").equal("Scott"))
+                                                                .asKeyList());
     }
 
     private void validate(final List<Key<PhotoWithKeywords>> found, final List<Key<PhotoWithKeywords>> notFound,

--- a/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
@@ -357,6 +357,30 @@ public class TestQuery extends TestBase {
                           .hasThisElement(new Keyword("Randy"))
                           .get());
     }
+    @Test
+    public void testComplexElemMatchQuery() {
+        Keyword oscar = new Keyword("Oscar", 42);
+        getDs().save(new PhotoWithKeywords(oscar, new Keyword("Jim", 12)));
+        Query<Keyword> query = getDs()
+            .createQuery(Keyword.class)
+            .filter("keyword = ", "Oscar")
+            .filter("score = ", 12);
+        assertNull(getDs().find(PhotoWithKeywords.class)
+                          .field("keywords")
+                          .hasThisElement(query)
+                          .get());
+
+        query = getDs()
+            .createQuery(Keyword.class)
+            .filter("score > ", 20)
+            .filter("score < ", 100);
+        List<PhotoWithKeywords> keywords = getDs().find(PhotoWithKeywords.class)
+                                                  .field("keywords")
+                                                  .hasThisElement(query)
+                                                  .asList();
+        assertEquals(1, keywords.size());
+        assertEquals(oscar, keywords.get(0).keywords.get(0));
+    }
 
     @Test
     public void testElemMatchQueryCanBeNegated() {
@@ -1165,6 +1189,31 @@ public class TestQuery extends TestBase {
 
         public Keyword(final Integer score) {
             this.score = score;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Keyword)) {
+                return false;
+            }
+
+            final Keyword keyword1 = (Keyword) o;
+
+            if (keyword != null ? !keyword.equals(keyword1.keyword) : keyword1.keyword != null) {
+                return false;
+            }
+            return score != null ? score.equals(keyword1.score) : keyword1.score == null;
+
+        }
+
+        @Override
+        public int hashCode() {
+            int result = keyword != null ? keyword.hashCode() : 0;
+            result = 31 * result + (score != null ? score.hashCode() : 0);
+            return result;
         }
     }
 

--- a/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestQuery.java
@@ -367,7 +367,7 @@ public class TestQuery extends TestBase {
             .filter("score = ", 12);
         assertNull(getDs().find(PhotoWithKeywords.class)
                           .field("keywords")
-                          .hasThisElement(query)
+                          .elemMatch(query)
                           .get());
 
         query = getDs()
@@ -376,7 +376,7 @@ public class TestQuery extends TestBase {
             .filter("score < ", 100);
         List<PhotoWithKeywords> keywords = getDs().find(PhotoWithKeywords.class)
                                                   .field("keywords")
-                                                  .hasThisElement(query)
+                                                  .elemMatch(query)
                                                   .asList();
         assertEquals(1, keywords.size());
         assertEquals(oscar, keywords.get(0).keywords.get(0));


### PR DESCRIPTION
This is a replacement implementation of $elemMatch.  The old "hasThisElement" and "doesNotHaveThisElement" are being deprecated as they are rather limited in what they support.  This resolves #970.