### PR TITLE
Fix error "execCommand == null!"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,7 +153,7 @@ def major(fullVersion) {
 def gitVersion() {
     def stdOut = new ByteArrayOutputStream()
     exec {
-        commandLine git, "rev-parse", "--abbrev-ref", "HEAD"
+        commandLine "git", "rev-parse", "--abbrev-ref", "HEAD"
         standardOutput = stdOut
         ignoreExitValue = true
     }


### PR DESCRIPTION
When building with gradle on windows or importing using intellij,
"execeCommand ==null" error occurs.
Fix this error