### PR TITLE
update shouldSaveClassName() to honor mapping data

### DIFF
--- a/config/clirr-exclude.yml
+++ b/config/clirr-exclude.yml
@@ -2,12 +2,4 @@
 differenceTypes: []
 
 packages:
-- net.sf.cglib.asm
-- net.sf.cglib.asm.signature
-- net.sf.cglib.beans
-- net.sf.cglib.core
-- net.sf.cglib.proxy
-- net.sf.cglib.reflect
-- net.sf.cglib.transform
-- net.sf.cglib.transform.impl
-- net.sf.cglib.util
+- com.mongodb.*

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -204,9 +204,11 @@ public class Mapper {
      */
     public List<MappedClass> getSubTypes(final MappedClass mc) {
         List<MappedClass> subtypes = new ArrayList<MappedClass>();
-        for (MappedClass mappedClass : getMappedClasses()) {
-            if (mappedClass.isSubType(mc)) {
-                subtypes.add(mappedClass);
+        if (mc != null) {
+            for (MappedClass mappedClass : getMappedClasses()) {
+                if (mappedClass.isSubType(mc)) {
+                    subtypes.add(mappedClass);
+                }
             }
         }
 
@@ -653,11 +655,11 @@ public class Mapper {
         } else if (value instanceof DBObject) {  //pass-through
             mappedValue = value;
         } else {
-            mappedValue = toMongoObject(value, EmbeddedMapper.shouldSaveClassName(value, mappedValue, mf));
+            mappedValue = toMongoObject(value, EmbeddedMapper.shouldSaveClassName(this, mf, value));
             if (mappedValue instanceof BasicDBList) {
                 final BasicDBList list = (BasicDBList) mappedValue;
                 if (list.size() != 0) {
-                    if (!EmbeddedMapper.shouldSaveClassName(extractFirstElement(value), list.get(0), mf)) {
+                    if (!EmbeddedMapper.shouldSaveClassName(this, mf, extractFirstElement(value))) {
                         for (Object o : list) {
                             if (o instanceof DBObject) {
                                 ((DBObject) o).removeField(CLASS_NAME_FIELDNAME);
@@ -665,7 +667,7 @@ public class Mapper {
                         }
                     }
                 }
-            } else if (mappedValue instanceof DBObject && !EmbeddedMapper.shouldSaveClassName(value, mappedValue, mf)) {
+            } else if (mappedValue instanceof DBObject && !EmbeddedMapper.shouldSaveClassName(this, mf, value)) {
                 ((DBObject) mappedValue).removeField(CLASS_NAME_FIELDNAME);
             }
         }

--- a/morphia/src/test/java/org/mongodb/morphia/TestUpdateOps.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestUpdateOps.java
@@ -30,6 +30,7 @@ import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.TestQuery.ContainsPic;
 import org.mongodb.morphia.query.TestQuery.Pic;
 import org.mongodb.morphia.query.UpdateOperations;
+import org.mongodb.morphia.query.UpdateOpsImpl;
 import org.mongodb.morphia.query.UpdateResults;
 import org.mongodb.morphia.query.ValidationException;
 import org.mongodb.morphia.testmodel.Circle;
@@ -39,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
@@ -86,6 +88,29 @@ public class TestUpdateOps extends TestBase {
         // then
         assertThat(updateResults.getUpdatedCount(), is(1));
         assertThat(getDs().find(Parent.class, "id", parentId).get().children, hasItem(new Child(childName, updatedLastName)));
+    }
+
+    @Test
+    public void testDisableValidation() {
+        Child child1 = new Child("James", "Rigney");
+
+        validateNoClassName("children", getDs().createUpdateOperations(Parent.class)
+                                               .removeAll("children", child1));
+
+        validateNoClassName("children", getDs().createUpdateOperations(Parent.class)
+                                               .disableValidation()
+                                               .removeAll("children", child1));
+
+        validateNoClassName("c", getDs().createUpdateOperations(Parent.class)
+                                        .disableValidation()
+                                        .removeAll("c", child1));
+    }
+
+    private void validateNoClassName(final String path, final UpdateOperations<Parent> ops) {
+        DBObject ops1 = ((UpdateOpsImpl) ops).getOps();
+        Map pull = (Map) ops1.get("$pull");
+        Map children = (Map) pull.get(path);
+        Assert.assertFalse(children.containsKey("className"));
     }
 
     @Test


### PR DESCRIPTION
This patch attempts to find any mapping data for a value to determine if className should be included.  Barring that a slightly more involved logic is used.

This resolves #379.