### PR TITLE
Better handling of nested types

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -604,6 +604,10 @@ public class Mapper {
      */
     @SuppressWarnings("deprecation")
     public Object toMongoObject(final MappedField mf, final MappedClass mc, final Object value) {
+        if (value == null) {
+            return null;
+        }
+
         Object mappedValue = value;
 
         if (value instanceof Query) {
@@ -623,22 +627,41 @@ public class Mapper {
                         }
                     }
                 } else {
-                    Key<?> key = null;
-                    if (value != null) {
-                        key = (value instanceof Key) ? (Key<?>) value : getKey(value);
-                    }
-                    if (key == null) {
-                        mappedValue = toMongoObject(value, false);
-                    } else {
-                        if (mf != null) {
-                            final Reference refAnn = mf.getAnnotation(Reference.class);
-                            mappedValue = refAnn != null && refAnn.idOnly()
-                                          ? keyToId(key)
-                                          : keyToDBRef(key);
+                    if (mf != null) {
+                        Reference refAnn = mf.getAnnotation(Reference.class);
+                        Class<?> idType = null;
+                        if (!mf.getType().equals(Key.class) && isMapped(mf.getType())) {
+                            idType = getMappedClass(mf.getType()).getMappedIdField().getType();
+                        }
+                        boolean valueIsIdType = mappedValue.getClass().equals(idType);
+                        if (refAnn != null) {
+                            if (!valueIsIdType) {
+                                Key<?> key = value instanceof Key ? (Key<?>) value : getKey(value);
+                                if (key != null) {
+                                    mappedValue = refAnn.idOnly()
+                                                  ? keyToId(key)
+                                                  : keyToDBRef(key);
+                                }
+                        /*
+                                                    if (mappedValue == value) {
+                                                        throw new ValidationException("cannot map to @Reference/Key<T>/DBRef field: " +
+                                                        value);
+                                                    }
+                        */
+                            }
+                        } else if (mf.getType().equals(Key.class)) {
+                            mappedValue = keyToDBRef(valueIsIdType
+                                          ? createKey(mf.getSubClass(), value)
+                                          : value instanceof Key ? (Key<?>) value : getKey(value));
                             if (mappedValue == value) {
-                                throw new ValidationException("cannot map to @Reference/Key<T>/DBRef field: " + value);
+                                throw new ValidationException("cannot map to Key<T> field: " + value);
                             }
                         }
+                    }
+
+                    if (mappedValue == value) {
+                        //                        mappedValue = getConverters().getEncoder(mappedValue, mf).encode(mappedValue, mf);
+                        mappedValue = toMongoObject(value, false);
                     }
                 }
             } catch (Exception e) {

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/Mapper.java
@@ -642,12 +642,6 @@ public class Mapper {
                                                   ? keyToId(key)
                                                   : keyToDBRef(key);
                                 }
-                        /*
-                                                    if (mappedValue == value) {
-                                                        throw new ValidationException("cannot map to @Reference/Key<T>/DBRef field: " +
-                                                        value);
-                                                    }
-                        */
                             }
                         } else if (mf.getType().equals(Key.class)) {
                             mappedValue = keyToDBRef(valueIsIdType
@@ -660,7 +654,6 @@ public class Mapper {
                     }
 
                     if (mappedValue == value) {
-                        //                        mappedValue = getConverters().getEncoder(mappedValue, mf).encode(mappedValue, mf);
                         mappedValue = toMongoObject(value, false);
                     }
                 }

--- a/morphia/src/test/java/org/mongodb/morphia/TestSerializedFormat.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestSerializedFormat.java
@@ -19,7 +19,6 @@ package org.mongodb.morphia;
 import com.mongodb.BasicDBObject;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mongodb.morphia.annotations.Embedded;
 import org.mongodb.morphia.annotations.Entity;

--- a/morphia/src/test/java/org/mongodb/morphia/TestSerializedFormat.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestSerializedFormat.java
@@ -45,7 +45,6 @@ import static org.mongodb.morphia.converters.DefaultConverters.JAVA_8;
 public class TestSerializedFormat extends TestBase {
     @Test
     @SuppressWarnings("deprecation")
-    @Ignore("queries on entities that aren't references still serialize as if they were")
     public void testQueryFormat() {
         Query<ReferenceType> query = getDs().find(ReferenceType.class)
                                             .field("selfReference").equal(new ReferenceType(1, "blah"))


### PR DESCRIPTION
This updates the logic here to be a bit smarter about when to serialize out as `DBRef`s or not.

fixes #1073 