### PR TITLE
Update PathTarget.java

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/internal/PathTarget.java
+++ b/morphia/src/main/java/org/mongodb/morphia/internal/PathTarget.java
@@ -111,7 +111,7 @@ public class PathTarget {
             if (field != null) {
                 if (!field.isMap()) {
                     translate(field.getNameToStore());
-                } else {
+                } else if(hasNext()) {
                     next();  // consume the map key segment
                 }
             } else {


### PR DESCRIPTION
Adding an extra check to prevent ArrayIndexOutOfBoundsException in case the unset element it is a hashmap but the key is not specify. Related to issue: https://github.com/mongodb/morphia/issues/1089