### PR TITLE
when collecting index definitions, look at the parent classes as well…

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/IndexHelper.java
+++ b/morphia/src/main/java/org/mongodb/morphia/IndexHelper.java
@@ -167,8 +167,7 @@ final class IndexHelper {
                 classes.add(mappedClass);
                 classes.addAll(mapper.getSubTypes(mappedClass));
                 for (MappedClass aClass : classes) {
-                    List<Index> indexes = collectIndexes(aClass, parents);
-                    for (Index index : indexes) {
+                    for (Index index : collectIndexes(aClass, parents)) {
                         List<Field> fields = new ArrayList<Field>();
                         for (Field field : index.fields()) {
                             fields.add(new FieldBuilder()

--- a/morphia/src/main/java/org/mongodb/morphia/mapping/MappedClass.java
+++ b/morphia/src/main/java/org/mongodb/morphia/mapping/MappedClass.java
@@ -148,12 +148,33 @@ public class MappedClass {
         }
     }
 
+    /**
+     * This is an internal method subject to change without notice.
+     *
+     * @return the parent class of this type if there is one null otherwise
+     *
+     * @since 1.3
+     */
+    public MappedClass getSuperClass() {
+        return superClass;
+    }
+
 
     /**
      * @return true if the MappedClass is an interface
      */
     public boolean isInterface() {
         return clazz.isInterface();
+    }
+
+    /**
+     * This is an internal method subject to change without notice.
+     *
+     * @return true if the MappedClass is abstract
+     * @since 1.3
+     */
+    public boolean isAbstract() {
+        return Modifier.isAbstract(clazz.getModifiers());
     }
 
     /**

--- a/morphia/src/test/java/org/mongodb/morphia/IndexHelperTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/IndexHelperTest.java
@@ -17,7 +17,6 @@
 package org.mongodb.morphia;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
@@ -37,7 +36,6 @@ import org.mongodb.morphia.annotations.Index;
 import org.mongodb.morphia.annotations.IndexOptions;
 import org.mongodb.morphia.annotations.Indexed;
 import org.mongodb.morphia.annotations.Indexes;
-import org.mongodb.morphia.annotations.Property;
 import org.mongodb.morphia.annotations.Text;
 import org.mongodb.morphia.mapping.MappedClass;
 import org.mongodb.morphia.mapping.Mapper;
@@ -118,6 +116,7 @@ public class IndexHelperTest extends TestBase {
         indexHelper.createIndex(collection, mapper.getMappedClass(IndexedClass.class), false);
         List<DBObject> indexInfo = getDs().getCollection(IndexedClass.class)
                                           .getIndexInfo();
+        assertEquals("Should have 6 indexes", 6, indexInfo.size());
         for (DBObject dbObject : indexInfo) {
             String name = dbObject.get("name").toString();
             if (name.equals("latitude_1")) {
@@ -479,7 +478,7 @@ public class IndexHelperTest extends TestBase {
     }
 
     @Indexes(@Index(fields = @Field("indexName")))
-    private static abstract class AbstractParent {
+    private abstract static class AbstractParent {
         @Id
         private ObjectId id;
         private double indexName;

--- a/morphia/src/test/java/org/mongodb/morphia/IndexHelperTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/IndexHelperTest.java
@@ -17,6 +17,7 @@
 package org.mongodb.morphia;
 
 import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.client.MongoCollection;
 import org.bson.BsonDocument;
@@ -39,6 +40,7 @@ import org.mongodb.morphia.annotations.Indexes;
 import org.mongodb.morphia.annotations.Property;
 import org.mongodb.morphia.annotations.Text;
 import org.mongodb.morphia.mapping.MappedClass;
+import org.mongodb.morphia.mapping.Mapper;
 import org.mongodb.morphia.mapping.MappingException;
 import org.mongodb.morphia.utils.IndexDirection;
 import org.mongodb.morphia.utils.IndexType;
@@ -64,7 +66,7 @@ public class IndexHelperTest extends TestBase {
 
     @Before
     public void before() {
-        getMorphia().map(IndexedClass.class, NestedClass.class, NestedClassImpl.class);
+        getMorphia().map(AbstractParent.class, IndexedClass.class, NestedClass.class, NestedClassImpl.class);
     }
 
     @Test
@@ -109,13 +111,13 @@ public class IndexHelperTest extends TestBase {
     @Test
     public void createIndex() {
         checkMinServerVersion(3.4);
-        MongoCollection<Document> collection = getDatabase().getCollection("indexes");
-        MappedClass mappedClass = getMorphia().getMapper().getMappedClass(IndexedClass.class);
+        String collectionName = getDs().getCollection(IndexedClass.class).getName();
+        MongoCollection<Document> collection = getDatabase().getCollection(collectionName);
+        Mapper mapper = getMorphia().getMapper();
 
-        indexHelper.createIndex(collection, mappedClass, false);
+        indexHelper.createIndex(collection, mapper.getMappedClass(IndexedClass.class), false);
         List<DBObject> indexInfo = getDs().getCollection(IndexedClass.class)
                                           .getIndexInfo();
-        assertEquals("Should have 5 indexes", 5, indexInfo.size());
         for (DBObject dbObject : indexInfo) {
             String name = dbObject.get("name").toString();
             if (name.equals("latitude_1")) {
@@ -129,13 +131,19 @@ public class IndexHelperTest extends TestBase {
                 assertEquals(parse("{ 'nest.name' : 1} "), dbObject.get("key"));
             } else if (name.equals("searchme")) {
                 assertEquals(parse("{ 'text' : 10 }"), dbObject.get("weights"));
+            } else if (name.equals("indexName_1")) {
+                assertEquals(parse("{'indexName': 1 }"), dbObject.get("key"));
             } else {
                 if (!"_id_".equals(dbObject.get("name"))) {
                     throw new MappingException("Found an index I wasn't expecting:  " + dbObject);
                 }
             }
-
         }
+
+        collection = getDatabase().getCollection(getDs().getCollection(AbstractParent.class).getName());
+        indexHelper.createIndex(collection, mapper.getMappedClass(AbstractParent.class), false);
+        indexInfo = getDs().getCollection(AbstractParent.class).getIndexInfo();
+        assertTrue("Shouldn't find any indexes: " + indexInfo, indexInfo.isEmpty());
 
     }
 
@@ -143,8 +151,7 @@ public class IndexHelperTest extends TestBase {
     public void findField() {
         MappedClass mappedClass = getMorphia().getMapper().getMappedClass(IndexedClass.class);
 
-        assertEquals("name", indexHelper.findField(mappedClass, new IndexOptionsBuilder(), singletonList("indexName")));
-        assertEquals("name", indexHelper.findField(mappedClass, new IndexOptionsBuilder(), singletonList("name")));
+        assertEquals("indexName", indexHelper.findField(mappedClass, new IndexOptionsBuilder(), singletonList("indexName")));
         assertEquals("nest.name", indexHelper.findField(mappedClass, new IndexOptionsBuilder(), asList("nested", "name")));
         assertEquals("nest.name", indexHelper.findField(mappedClass, new IndexOptionsBuilder(), asList("nest", "name")));
 
@@ -254,7 +261,7 @@ public class IndexHelperTest extends TestBase {
         List<DBObject> indexInfo = getDs().getCollection(IndexedClass.class)
                                           .getIndexInfo();
         for (DBObject dbObject : indexInfo) {
-            if (dbObject.get("name").equals("index_name")) {
+            if (dbObject.get("name").equals("index_indexName")) {
                 checkIndex(dbObject);
             }
         }
@@ -454,13 +461,9 @@ public class IndexHelperTest extends TestBase {
 
     @Entity("indexes")
     @Indexes(@Index(fields = @Field("latitude")))
-    private static class IndexedClass {
-        @Id
-        private ObjectId id;
+    private static class IndexedClass extends AbstractParent {
         @Text(value = 10, options = @IndexOptions(name = "searchme"))
         private String text;
-        @Property("name")
-        private double indexName;
         private double latitude;
         @Embedded("nest")
         private NestedClass nested;
@@ -473,5 +476,12 @@ public class IndexHelperTest extends TestBase {
     private static class NestedClassImpl implements NestedClass {
         @Indexed
         private String name;
+    }
+
+    @Indexes(@Index(fields = @Field("indexName")))
+    private static abstract class AbstractParent {
+        @Id
+        private ObjectId id;
+        private double indexName;
     }
 }


### PR DESCRIPTION
… as the nested types for definitions.

don't create indexes when the mapped class is abstract.

fixes #1086