### PR TITLE
deprecate the `updateFirst` and `update*` methods

### DIFF
--- a/morphia/src/main/java/org/mongodb/morphia/Datastore.java
+++ b/morphia/src/main/java/org/mongodb/morphia/Datastore.java
@@ -725,7 +725,9 @@ public interface Datastore {
      * @param createIfMissing if true, a document will be created if none can be found that match the query
      * @param <T>             the type of the entity
      * @return the results of the updates
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with upsert set to the value of createIfMissing
      */
+    @Deprecated
     <T> UpdateResults update(Query<T> query, UpdateOperations<T> operations, boolean createIfMissing);
 
     /**
@@ -739,7 +741,9 @@ public interface Datastore {
      * @param wc              the WriteConcern to use
      * @param <T>             the type of the entity
      * @return the results of the updates
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with upsert set to the value of createIfMissing
      */
+    @Deprecated
     <T> UpdateResults update(Query<T> query, UpdateOperations<T> operations, boolean createIfMissing, WriteConcern wc);
 
     /**
@@ -749,8 +753,23 @@ public interface Datastore {
      * @param operations the update operations to perform
      * @param <T>        the type of the entity
      * @return the results of the update
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with multi set to false (the default value)
      */
+    @Deprecated
     <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations);
+
+    /**
+     * Updates the first entity found with the operations; this is an atomic operation
+     *
+     * @param query      the query used to match the document to update
+     * @param operations the update operations to perform
+     * @param options    the options to apply to the update
+     * @param <T>        the type of the entity
+     * @return the results of the update
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with multi set to false (the default value)
+     */
+    @Deprecated
+    <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations, UpdateOptions options);
 
     /**
      * Updates the first entity found with the operations, if nothing is found insert the update as an entity if "createIfMissing" is true.
@@ -760,7 +779,9 @@ public interface Datastore {
      * @param createIfMissing if true, a document will be created if none can be found that match the query
      * @param <T>             the type of the entity
      * @return the results of the updates
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with upsert set to the value of createIfMissing
      */
+    @Deprecated
     <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations, boolean createIfMissing);
 
     /**
@@ -772,7 +793,9 @@ public interface Datastore {
      * @param wc              the WriteConcern to use
      * @param <T>             the type of the entity
      * @return the results of the updates
+     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with upsert set to the value of createIfMissing
      */
+    @Deprecated
     <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations, boolean createIfMissing, WriteConcern wc);
 
     /**
@@ -786,6 +809,8 @@ public interface Datastore {
      * @param createIfMissing if true, a document will be created if none can be found that match the query
      * @param <T>             the type of the entity
      * @return the results of the updates
+     * @deprecated use {@link #find(Class)} and {@link #save(Object)} directly
      */
+    @Deprecated
     <T> UpdateResults updateFirst(Query<T> query, T entity, boolean createIfMissing);
 }

--- a/morphia/src/main/java/org/mongodb/morphia/Datastore.java
+++ b/morphia/src/main/java/org/mongodb/morphia/Datastore.java
@@ -759,19 +759,6 @@ public interface Datastore {
     <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations);
 
     /**
-     * Updates the first entity found with the operations; this is an atomic operation
-     *
-     * @param query      the query used to match the document to update
-     * @param operations the update operations to perform
-     * @param options    the options to apply to the update
-     * @param <T>        the type of the entity
-     * @return the results of the update
-     * @deprecated use {@link #update(Query, UpdateOperations, UpdateOptions)} with multi set to false (the default value)
-     */
-    @Deprecated
-    <T> UpdateResults updateFirst(Query<T> query, UpdateOperations<T> operations, UpdateOptions options);
-
-    /**
      * Updates the first entity found with the operations, if nothing is found insert the update as an entity if "createIfMissing" is true.
      *
      * @param query           the query used to match the documents to update

--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -813,6 +813,7 @@ public class DatastoreImpl implements AdvancedDatastore {
     }
 
     @Override
+    @Deprecated
     public <T> UpdateResults update(final Query<T> query, final UpdateOperations<T> operations, final boolean createIfMissing) {
         return update(query, operations, new UpdateOptions()
             .upsert(createIfMissing)
@@ -820,6 +821,7 @@ public class DatastoreImpl implements AdvancedDatastore {
     }
 
     @Override
+    @Deprecated
     public <T> UpdateResults update(final Query<T> query, final UpdateOperations<T> operations, final boolean createIfMissing,
                                     final WriteConcern wc) {
         return update(query, operations, new UpdateOptions()
@@ -829,17 +831,28 @@ public class DatastoreImpl implements AdvancedDatastore {
     }
 
     @Override
+    @Deprecated
     public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations) {
         return update(query, operations, new UpdateOptions());
     }
 
     @Override
+    @Deprecated
+    public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations, final UpdateOptions options) {
+        return update(query, operations, options.copy()
+                                                .multi(false));
+    }
+
+    @Override
+    @Deprecated
     public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations, final boolean createIfMissing) {
-        return update(query, operations, new UpdateOptions().upsert(createIfMissing));
+        return update(query, operations, new UpdateOptions()
+            .upsert(createIfMissing));
 
     }
 
     @Override
+    @Deprecated
     public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations, final boolean createIfMissing,
                                          final WriteConcern wc) {
         return update(query, operations, new UpdateOptions()
@@ -848,6 +861,7 @@ public class DatastoreImpl implements AdvancedDatastore {
     }
 
     @Override
+    @Deprecated
     public <T> UpdateResults updateFirst(final Query<T> query, final T entity, final boolean createIfMissing) {
         if (getMapper().getMappedClass(entity).getMappedVersionField() != null) {
             throw new UnsupportedOperationException("updateFirst() is not supported with versioned entities");

--- a/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
+++ b/morphia/src/main/java/org/mongodb/morphia/DatastoreImpl.java
@@ -801,7 +801,7 @@ public class DatastoreImpl implements AdvancedDatastore {
         if (clazz == null) {
             clazz = (Class<T>) mapper.getClassFromCollection(key.getCollection());
         }
-        return updateFirst(createQuery(clazz).disableValidation().filter(Mapper.ID_KEY, key.getId()), operations);
+        return update(createQuery(clazz).disableValidation().filter(Mapper.ID_KEY, key.getId()), operations, new UpdateOptions());
     }
 
     @Override
@@ -834,13 +834,6 @@ public class DatastoreImpl implements AdvancedDatastore {
     @Deprecated
     public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations) {
         return update(query, operations, new UpdateOptions());
-    }
-
-    @Override
-    @Deprecated
-    public <T> UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> operations, final UpdateOptions options) {
-        return update(query, operations, options.copy()
-                                                .multi(false));
     }
 
     @Override

--- a/morphia/src/main/java/org/mongodb/morphia/dao/BasicDAO.java
+++ b/morphia/src/main/java/org/mongodb/morphia/dao/BasicDAO.java
@@ -8,6 +8,7 @@ import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.InsertOptions;
 import org.mongodb.morphia.Key;
 import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.UpdateOptions;
 import org.mongodb.morphia.query.FindOptions;
 import org.mongodb.morphia.query.Query;
 import org.mongodb.morphia.query.QueryResults;
@@ -242,7 +243,7 @@ public class BasicDAO<T, K> implements DAO<T, K> {
 
     @Override
     public UpdateResults updateFirst(final Query<T> query, final UpdateOperations<T> ops) {
-        return ds.updateFirst(query, ops);
+        return ds.update(query, ops, new UpdateOptions());
     }
 
     /**

--- a/morphia/src/test/java/org/mongodb/morphia/TestUpdateOps.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestUpdateOps.java
@@ -55,6 +55,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -124,71 +125,60 @@ public class TestUpdateOps extends TestBase {
         checkMinServerVersion(2.6);
 
         ContainsIntArray cIntArray = new ContainsIntArray();
-        getDs().save(cIntArray);
-        ContainsIntArray cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values.length, is(3));
-        assertThat(cIALoaded.values, is((new ContainsIntArray()).values));
+        Datastore ds = getDs();
+        ds.save(cIntArray);
+
+        assertThat(ds.get(cIntArray).values, is((new ContainsIntArray()).values));
 
         //add 4 to array
-        UpdateResults res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                                getDs().createUpdateOperations(ContainsIntArray.class)
-                                                       .add("values", 4, false));
-        assertUpdated(res, 1);
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                            .add("values", 4, false)),
+                      1);
 
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4}));
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4}));
 
         //add unique (4) -- noop
-        res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .add("values", 4, false));
-        assertUpdated(res, 1);
-
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4}));
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                            .add("values", 4, false)),
+                      1);
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4}));
 
         //add dup 4
-        res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class).add("values", 4, true));
-        assertUpdated(res, 1);
-
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4, 4}));
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                            .add("values", 4, true)),
+                      1);
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 4}));
 
         //cleanup for next tests
-        getDs().delete(getDs().find(ContainsIntArray.class));
-        cIntArray = getDs().getByKey(ContainsIntArray.class, getDs().save(new ContainsIntArray()));
+        ds.delete(ds.find(ContainsIntArray.class));
+        cIntArray = ds.getByKey(ContainsIntArray.class, ds.save(new ContainsIntArray()));
 
         //add [4,5]
         final List<Integer> newValues = new ArrayList<Integer>();
         newValues.add(4);
         newValues.add(5);
-        res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addAll("values", newValues, false));
-        assertUpdated(res, 1);
-
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4, 5}));
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                            .addAll("values", newValues, false)),
+                      1);
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 5}));
 
         //add them again... noop
-        res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addAll("values", newValues, false));
-        assertUpdated(res, 1);
-
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4, 5}));
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                            .addAll("values", newValues, false)),
+                      1);
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 5}));
 
         //add dups [4,5]
-        res = getDs().updateFirst(getDs().createQuery(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addAll("values", newValues, true));
-        assertUpdated(res, 1);
-
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4, 5, 4, 5}));
-
+        assertUpdated(ds.update(ds.createQuery(ContainsIntArray.class),
+                                ds.createUpdateOperations(ContainsIntArray.class)
+                                  .addAll("values", newValues, true)),
+                      1);
+        assertThat(ds.get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 5, 4, 5}));
     }
 
     @Test
@@ -227,38 +217,74 @@ public class TestUpdateOps extends TestBase {
     public void testAddToSet() throws Exception {
         ContainsIntArray cIntArray = new ContainsIntArray();
         getDs().save(cIntArray);
+
         assertThat(getDs().get(cIntArray).values, is((new ContainsIntArray()).values));
 
-        //add 4 to array
-        UpdateResults res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                                getDs().createUpdateOperations(ContainsIntArray.class)
-                                                       .addToSet("values", 4));
-        assertUpdated(res, 1);
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .addToSet("values", 5)),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 5}));
 
-        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4}));
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .addToSet("values", 4)),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 5, 4}));
 
-        res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addToSet("values", 4));
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .addToSet("values", asList(8, 9))),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 5, 4, 8, 9}));
 
-        assertUpdated(res, 1);
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .addToSet("values", asList(4, 5))),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 5, 4, 8, 9}));
+    }
 
-        final List<Integer> newValues = new ArrayList<Integer>();
-        newValues.add(4);
-        newValues.add(5);
-        res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addToSet("values", newValues));
-        assertUpdated(res, 1);
+    @Test
+    @SuppressWarnings("deprecation")
+    public void testUpdateFirst() throws Exception {
+        ContainsIntArray cIntArray = new ContainsIntArray();
+        ContainsIntArray control = new ContainsIntArray();
+        Datastore ds = getDs();
+        ds.save(cIntArray, control);
 
-        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 5}));
+        assertThat(ds.get(cIntArray).values, is((new ContainsIntArray()).values));
+        Query<ContainsIntArray> query = ds.find(ContainsIntArray.class);
 
-        res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class)
-                                         .addToSet("values", newValues));
-        assertUpdated(res, 1);
+        doUpdates(cIntArray, control, query, ds.createUpdateOperations(ContainsIntArray.class)
+                                                    .addToSet("values", 4),
+                  new Integer[]{1, 2, 3, 4});
 
-        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 5}));
+
+        doUpdates(cIntArray, control, query, ds.createUpdateOperations(ContainsIntArray.class)
+                                                    .addToSet("values", asList(4, 5)),
+                  new Integer[]{1, 2, 3, 4, 5});
+
+
+        assertInserted(ds.updateFirst(ds.find(ContainsIntArray.class)
+                                       .filter("values", new Integer[]{4, 5, 7}),
+                                     ds.createUpdateOperations(ContainsIntArray.class)
+                                       .addToSet("values", 6), true));
+        assertNotNull(ds.find(ContainsIntArray.class)
+                        .filter("values", new Integer[]{4, 5, 7, 6}));
+    }
+
+    @SuppressWarnings("deprecation")
+    private void doUpdates(final ContainsIntArray updated, final ContainsIntArray control,
+                           final Query<ContainsIntArray> query, final UpdateOperations<ContainsIntArray> operations,
+                           final Integer[] target) {
+        assertUpdated(getDs().updateFirst(query, operations), 1);
+        assertThat(getDs().get(updated).values, is(target));
+        assertThat(getDs().get(control).values, is(new Integer[]{1, 2, 3}));
+
+        assertUpdated(getDs().update(query, operations, new UpdateOptions()), 1);
+        assertThat(getDs().get(updated).values, is(target));
+        assertThat(getDs().get(control).values, is(new Integer[]{1, 2, 3}));
     }
 
     @Test
@@ -267,12 +293,16 @@ public class TestUpdateOps extends TestBase {
         getDs().save(c);
         c = new Circle(12D);
         getDs().save(c);
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class),
-                                                getDs().createUpdateOperations(Circle.class).inc("radius", 1D));
-        assertUpdated(res, 1);
+        assertUpdated(getDs().update(getDs().find(Circle.class),
+                                     getDs().createUpdateOperations(Circle.class)
+                                            .inc("radius", 1D),
+                                     new UpdateOptions()),
+                      1);
 
-        res = getDs().update(getDs().find(Circle.class), getDs().createUpdateOperations(Circle.class).inc("radius"));
-        assertUpdated(res, 2);
+        assertUpdated(getDs().update(getDs().find(Circle.class),
+                                     getDs().createUpdateOperations(Circle.class)
+                                            .inc("radius")),
+                      2);
 
         //test possible data type change.
         final Circle updatedCircle = getDs().find(Circle.class).filter("radius", 13).get();
@@ -341,17 +371,14 @@ public class TestUpdateOps extends TestBase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testInsertUpdate() throws Exception {
-        final UpdateResults res = getDs().update(getDs().find(Circle.class).field("radius").equal(0),
-                                                 getDs().createUpdateOperations(Circle.class).inc("radius", 1D), true);
-        assertInserted(res);
-    }
-
-    @Test
-    public void testInsertUpdatesUnsafe() throws Exception {
-        getDs().update(getDs().find(Circle.class).field("radius").equal(0),
-                       getDs().createUpdateOperations(Circle.class).inc("radius", 1D), true, WriteConcern.UNACKNOWLEDGED);
-        assertThat(getDs().getCount(Circle.class), is(1L));
+        assertInserted(getDs().update(getDs().find(Circle.class).field("radius").equal(0),
+                                      getDs().createUpdateOperations(Circle.class).inc("radius", 1D), true));
+        assertInserted(getDs().update(getDs().find(Circle.class).field("radius").equal(0),
+                                      getDs().createUpdateOperations(Circle.class).inc("radius", 1D),
+                                      new UpdateOptions()
+                                          .upsert(true)));
     }
 
     @Test
@@ -360,20 +387,17 @@ public class TestUpdateOps extends TestBase {
         pic.setName("fist");
         final Key<Pic> picKey = getDs().save(pic);
 
-        //test with Key<Pic>
-        UpdateResults res = getDs().updateFirst(getDs().find(ContainsPic.class).filter("name", "first").filter("pic", picKey),
-                                                getDs().createUpdateOperations(ContainsPic.class).set("name", "A"), true);
-
-        assertInserted(res);
+        assertInserted(getDs().update(getDs().find(ContainsPic.class).filter("name", "first").filter("pic", picKey),
+                                           getDs().createUpdateOperations(ContainsPic.class)
+                                                  .set("name", "A"),
+                                           new UpdateOptions().upsert(true)));
         assertThat(getDs().find(ContainsPic.class).count(), is(1L));
-
         getDs().delete(getDs().find(ContainsPic.class));
 
-        //test with pic object
-        res = getDs().updateFirst(getDs().find(ContainsPic.class).filter("name", "first").filter("pic", pic),
-                                  getDs().createUpdateOperations(ContainsPic.class).set("name", "second"), true);
-
-        assertInserted(res);
+        assertInserted(getDs().update(getDs().find(ContainsPic.class).filter("name", "first").filter("pic", pic),
+                                           getDs().createUpdateOperations(ContainsPic.class).set("name", "second"),
+                                      new UpdateOptions()
+                                          .upsert(true)));
         assertThat(getDs().find(ContainsPic.class).count(), is(1L));
 
         //test reading the object.
@@ -383,72 +407,47 @@ public class TestUpdateOps extends TestBase {
         assertThat(cp.getPic(), is(notNullValue()));
         assertThat(cp.getPic().getName(), is(notNullValue()));
         assertThat(cp.getPic().getName(), is("fist"));
-
     }
 
     @Test
     public void testMaxKeepsCurrentDocumentValueWhenThisIsLargerThanSuppliedValue() throws Exception {
         checkMinServerVersion(2.6);
-        // given
         final ObjectId id = new ObjectId();
         final double originalValue = 2D;
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", originalValue), true);
 
-        assertInserted(res);
+        Datastore ds = getDs();
+        assertInserted(ds.update(ds.find(Circle.class)
+                                   .field("id").equal(id),
+                                 ds.createUpdateOperations(Circle.class)
+                                   .setOnInsert("radius", originalValue),
+                                 new UpdateOptions()
+                                     .upsert(true)));
 
-        // when
-        res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                  getDs().createUpdateOperations(Circle.class).max("radius", 1D), true);
+        assertUpdated(ds.update(ds.find(Circle.class)
+                                  .field("id").equal(id),
+                                ds.createUpdateOperations(Circle.class)
+                                  .max("radius", 1D),
+                                new UpdateOptions()
+                                    .upsert(true)),
+                      1);
 
-        // then
-        assertUpdated(res, 1);
 
-        final Circle updatedCircle = getDs().get(Circle.class, id);
-        assertThat(updatedCircle, is(notNullValue()));
-        assertThat(updatedCircle.getRadius(), is(originalValue));
-    }
-
-    @Test
-    public void testMaxUsesSuppliedValueWhenThisIsLargerThanCurrentDocumentValue() throws Exception {
-        checkMinServerVersion(2.6);
-        // given
-        final ObjectId id = new ObjectId();
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 1D), true);
-
-        assertInserted(res);
-
-        // when
-        final double newHigherValue = 2D;
-        res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                  getDs().createUpdateOperations(Circle.class).max("radius", newHigherValue), true);
-
-        // then
-        assertUpdated(res, 1);
-
-        final Circle updatedCircle = getDs().get(Circle.class, id);
-        assertThat(updatedCircle, is(notNullValue()));
-        assertThat(updatedCircle.getRadius(), is(newHigherValue));
+        assertThat(ds.get(Circle.class, id).getRadius(), is(originalValue));
     }
 
     @Test
     public void testMinKeepsCurrentDocumentValueWhenThisIsSmallerThanSuppliedValue() throws Exception {
         checkMinServerVersion(2.6);
-        // given
         final ObjectId id = new ObjectId();
         final double originalValue = 3D;
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", originalValue), true);
 
-        assertInserted(res);
+        assertInserted(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                      getDs().createUpdateOperations(Circle.class).setOnInsert("radius", originalValue),
+                                      new UpdateOptions().upsert(true)));
 
-        // when
-        res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                  getDs().createUpdateOperations(Circle.class).min("radius", 5D), true);
-
-        // then
-        assertUpdated(res, 1);
+        assertUpdated(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                     getDs().createUpdateOperations(Circle.class).min("radius", 5D),
+                                     new UpdateOptions().upsert(true)), 1);
 
         final Circle updatedCircle = getDs().get(Circle.class, id);
         assertThat(updatedCircle, is(notNullValue()));
@@ -458,20 +457,17 @@ public class TestUpdateOps extends TestBase {
     @Test
     public void testMinUsesSuppliedValueWhenThisIsSmallerThanCurrentDocumentValue() throws Exception {
         checkMinServerVersion(2.6);
-        // given
         final ObjectId id = new ObjectId();
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 3D), true);
-
-        assertInserted(res);
-
-        // when
         final double newLowerValue = 2D;
-        res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                  getDs().createUpdateOperations(Circle.class).min("radius", newLowerValue), true);
 
-        // then
-        assertUpdated(res, 1);
+        assertInserted(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                      getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 3D),
+                                      new UpdateOptions().upsert(true)));
+
+
+        assertUpdated(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                     getDs().createUpdateOperations(Circle.class).min("radius", newLowerValue),
+                                     new UpdateOptions().upsert(true)), 1);
 
         final Circle updatedCircle = getDs().get(Circle.class, id);
         assertThat(updatedCircle, is(notNullValue()));
@@ -483,43 +479,48 @@ public class TestUpdateOps extends TestBase {
         checkMinServerVersion(2.6);
         ContainsIntArray cIntArray = new ContainsIntArray();
         getDs().save(cIntArray);
-        ContainsIntArray cIALoaded;
         assertThat(getDs().get(cIntArray).values, is((new ContainsIntArray()).values));
 
-        getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                            getDs().createUpdateOperations(ContainsIntArray.class)
-                                   .push("values", 4));
+        getDs().update(getDs().find(ContainsIntArray.class),
+                       getDs().createUpdateOperations(ContainsIntArray.class)
+                              .push("values", 4),
+                       new UpdateOptions()
+                           .multi(false));
 
         assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4}));
 
-        getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                            getDs().createUpdateOperations(ContainsIntArray.class)
-                                   .push("values", 4));
+        getDs().update(getDs().find(ContainsIntArray.class),
+                       getDs().createUpdateOperations(ContainsIntArray.class)
+                              .push("values", 4),
+                       new UpdateOptions()
+                           .multi(false));
 
         assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 4}));
 
-        getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                            getDs().createUpdateOperations(ContainsIntArray.class)
-                                   .push("values", asList(5, 6)));
+        getDs().update(getDs().find(ContainsIntArray.class),
+                       getDs().createUpdateOperations(ContainsIntArray.class)
+                              .push("values", asList(5, 6)),
+                       new UpdateOptions()
+                           .multi(false));
 
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 3, 4, 4, 5, 6}));
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 3, 4, 4, 5, 6}));
 
-        getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                            getDs().createUpdateOperations(ContainsIntArray.class)
-                                   .push("values", 12, options().position(2)));
+        getDs().update(getDs().find(ContainsIntArray.class),
+                       getDs().createUpdateOperations(ContainsIntArray.class)
+                              .push("values", 12, options().position(2)),
+                       new UpdateOptions()
+                           .multi(false));
 
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 12, 3, 4, 4, 5, 6}));
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 12, 3, 4, 4, 5, 6}));
 
 
-        getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                            getDs().createUpdateOperations(ContainsIntArray.class)
-                                   .push("values", asList(99, 98, 97), options().position(4)));
+        getDs().update(getDs().find(ContainsIntArray.class),
+                       getDs().createUpdateOperations(ContainsIntArray.class)
+                              .push("values", asList(99, 98, 97), options().position(4)),
+                       new UpdateOptions()
+                           .multi(false));
 
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{1, 2, 12, 3, 99, 98, 97, 4, 4, 5, 6}));
-
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{1, 2, 12, 3, 99, 98, 97, 4, 4, 5, 6}));
     }
 
     @Test
@@ -589,13 +590,11 @@ public class TestUpdateOps extends TestBase {
             getDs().find(DumbColl.class).field("opaqueId").equalIgnoreCase("ID"),
             getAds().createUpdateOperations(DumbColl.class,
                 new BasicDBObject("$pull", new BasicDBObject("fromArray", new BasicDBObject("whereId", "not there")))));
-        LOG.debug("************ deleteResults = " + deleteResults);
 
-        deleteResults = getDs().update(
+        getDs().update(
             getDs().find(DumbColl.class).field("opaqueId").equalIgnoreCase("ID"),
             getAds().createUpdateOperations(DumbColl.class)
                 .removeAll("fromArray", new DumbArrayElement("something")));
-        LOG.debug("************ deleteResults = " + deleteResults);
     }
 
     @Test
@@ -606,29 +605,32 @@ public class TestUpdateOps extends TestBase {
         assertThat(cIALoaded.values.length, is(3));
         assertThat(cIALoaded.values, is((new ContainsIntArray()).values));
 
-        //remove 1
-        UpdateResults res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                                getDs().createUpdateOperations(ContainsIntArray.class).removeFirst("values"));
-        assertUpdated(res, 1);
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{2, 3}));
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .removeFirst("values"),
+                                     new UpdateOptions()
+                                         .multi(false)),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{2, 3}));
 
-        //remove 3
-        res = getDs().updateFirst(getDs().find(ContainsIntArray.class),
-                                  getDs().createUpdateOperations(ContainsIntArray.class).removeLast("values"));
-        assertUpdated(res, 1);
-        cIALoaded = getDs().get(cIntArray);
-        assertThat(cIALoaded.values, is(new Integer[]{2}));
+        assertUpdated(getDs().update(getDs().find(ContainsIntArray.class),
+                                     getDs().createUpdateOperations(ContainsIntArray.class)
+                                            .removeLast("values"),
+                                     new UpdateOptions()
+                                         .multi(false)),
+                      1);
+        assertThat(getDs().get(cIntArray).values, is(new Integer[]{2}));
     }
 
     @Test
     public void testSetOnInsertWhenInserting() throws Exception {
         checkMinServerVersion(2.4);
         ObjectId id = new ObjectId();
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 2D), true);
 
-        assertInserted(res);
+        assertInserted(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                      getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 2D),
+                                      new UpdateOptions()
+                                          .upsert(true)));
 
         final Circle updatedCircle = getDs().get(Circle.class, id);
 
@@ -640,15 +642,17 @@ public class TestUpdateOps extends TestBase {
     public void testSetOnInsertWhenUpdating() throws Exception {
         checkMinServerVersion(2.4);
         ObjectId id = new ObjectId();
-        UpdateResults res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                                getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 1D), true);
 
-        assertInserted(res);
+        assertInserted(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                      getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 1D),
+                                      new UpdateOptions()
+                                          .upsert(true)));
 
-        res = getDs().updateFirst(getDs().find(Circle.class).field("id").equal(id),
-                                  getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 2D), true);
-
-        assertUpdated(res, 1);
+        assertUpdated(getDs().update(getDs().find(Circle.class).field("id").equal(id),
+                                     getDs().createUpdateOperations(Circle.class).setOnInsert("radius", 2D),
+                                     new UpdateOptions()
+                                         .upsert(true)),
+                      1);
 
         final Circle updatedCircle = getDs().get(Circle.class, id);
 
@@ -661,14 +665,20 @@ public class TestUpdateOps extends TestBase {
         Datastore ds = getDs();
         final Key<Circle> key = ds.save(new Circle(1));
 
-        assertUpdated(ds.updateFirst(ds.find(Circle.class).filter("radius", 1D),
-                                     ds.createUpdateOperations(Circle.class).set("radius", 2D)), 1);
+        assertUpdated(ds.update(ds.find(Circle.class).filter("radius", 1D),
+                                ds.createUpdateOperations(Circle.class).set("radius", 2D),
+                                new UpdateOptions()
+                                    .multi(false)),
+                      1);
 
         assertThat(ds.getByKey(Circle.class, key).getRadius(), is(2D));
 
 
-        assertUpdated(ds.updateFirst(ds.find(Circle.class).filter("radius", 2D),
-                                     ds.createUpdateOperations(Circle.class).unset("radius")), 1);
+        assertUpdated(ds.update(ds.find(Circle.class).filter("radius", 2D),
+                                ds.createUpdateOperations(Circle.class).unset("radius"),
+                                new UpdateOptions()
+                                    .multi(false)),
+                      1);
 
         assertThat(ds.getByKey(Circle.class, key).getRadius(), is(0D));
 
@@ -698,7 +708,7 @@ public class TestUpdateOps extends TestBase {
         BasicDBObject object = new BasicDBObject("new", "value");
         updateOperations.set("raw", object);
 
-        getDs().updateFirst(query, updateOperations, false);
+        getDs().update(query, updateOperations, new UpdateOptions());
 
         List<EntityLogs> list = getDs().find(EntityLogs.class).asList();
         for (int i = 0; i < list.size(); i++) {
@@ -708,6 +718,7 @@ public class TestUpdateOps extends TestBase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testUpdateFirstNoCreateWithEntity() {
         List<EntityLogs> logs = new ArrayList<EntityLogs>();
         for (int i = 0; i < 100; i++) {
@@ -737,17 +748,15 @@ public class TestUpdateOps extends TestBase {
         }
         EntityLogs logs1 = logs.get(0);
 
-        Query<EntityLogs> query = getDs().find(EntityLogs.class);
-        UpdateOperations<EntityLogs> updateOperations = getDs().createUpdateOperations(EntityLogs.class);
-        BasicDBObject object = new BasicDBObject("new", "value");
-        updateOperations.set("raw", object);
-
-        getDs().updateFirst(query, updateOperations, false);
+        getDs().update(getDs().find(EntityLogs.class),
+                       getDs().createUpdateOperations(EntityLogs.class)
+                              .set("raw", new BasicDBObject("new", "value")),
+                       new UpdateOptions());
 
         List<EntityLogs> list = getDs().find(EntityLogs.class).asList();
         for (int i = 0; i < list.size(); i++) {
             final EntityLogs entityLogs = list.get(i);
-            assertEquals(entityLogs.id.equals(logs1.id) ? object : logs.get(i).raw, entityLogs.raw);
+            assertEquals(entityLogs.id.equals(logs1.id) ? new BasicDBObject("new", "value") : logs.get(i).raw, entityLogs.raw);
         }
     }
 
@@ -756,32 +765,35 @@ public class TestUpdateOps extends TestBase {
         final ContainsPicKey cpk = new ContainsPicKey();
         cpk.name = "cpk one";
 
-        getDs().save(cpk);
+        Datastore ds = getDs();
+        ds.save(cpk);
 
         final Pic pic = new Pic();
         pic.setName("fist again");
-        final Key<Pic> picKey = getDs().save(pic);
+        final Key<Pic> picKey = ds.save(pic);
         // picKey = getDs().getKey(pic);
 
 
         //test with Key<Pic>
-        final UpdateResults res = getDs().updateFirst(getDs().find(ContainsPicKey.class).filter("name", cpk.name),
-                                                      getDs().createUpdateOperations(ContainsPicKey.class).set("pic", pic));
 
-        assertThat(res.getUpdatedCount(), is(1));
+        assertThat(ds.update(ds.find(ContainsPicKey.class).filter("name", cpk.name),
+                             ds.createUpdateOperations(ContainsPicKey.class).set("pic", pic),
+                             new UpdateOptions()).getUpdatedCount(),
+                   is(1));
 
         //test reading the object.
-        final ContainsPicKey cpk2 = getDs().find(ContainsPicKey.class).get();
+        final ContainsPicKey cpk2 = ds.find(ContainsPicKey.class).get();
         assertThat(cpk2, is(notNullValue()));
         assertThat(cpk.name, is(cpk2.name));
         assertThat(cpk2.pic, is(notNullValue()));
         assertThat(picKey, is(cpk2.pic));
 
-        getDs().updateFirst(getDs().find(ContainsPicKey.class).filter("name", cpk.name),
-                            getDs().createUpdateOperations(ContainsPicKey.class).set("pic", picKey));
+        ds.update(ds.find(ContainsPicKey.class).filter("name", cpk.name),
+                  ds.createUpdateOperations(ContainsPicKey.class).set("pic", picKey),
+                  new UpdateOptions());
 
         //test reading the object.
-        final ContainsPicKey cpk3 = getDs().find(ContainsPicKey.class).get();
+        final ContainsPicKey cpk3 = ds.find(ContainsPicKey.class).get();
         assertThat(cpk3, is(notNullValue()));
         assertThat(cpk.name, is(cpk3.name));
         assertThat(cpk3.pic, is(notNullValue()));
@@ -803,8 +815,9 @@ public class TestUpdateOps extends TestBase {
         cpk.keys = singletonList(picKey);
 
         //test with Key<Pic>
-        final UpdateResults res = ds.updateFirst(ds.find(ContainsPicKey.class).filter("name", cpk.name),
-                                                 ds.createUpdateOperations(ContainsPicKey.class).set("keys", cpk.keys));
+        final UpdateResults res = ds.update(ds.find(ContainsPicKey.class).filter("name", cpk.name),
+                                            ds.createUpdateOperations(ContainsPicKey.class).set("keys", cpk.keys),
+                                            new UpdateOptions());
 
         assertThat(res.getUpdatedCount(), is(1));
 
@@ -828,10 +841,13 @@ public class TestUpdateOps extends TestBase {
 
 
         //test with Key<Pic>
-        final UpdateResults res = getDs().updateFirst(getDs().find(ContainsPic.class).filter("name", cp.getName()),
-                                                      getDs().createUpdateOperations(ContainsPic.class).set("pic", pic));
 
-        assertThat(res.getUpdatedCount(), is(1));
+        assertThat(getDs().update(getDs().find(ContainsPic.class).filter("name", cp.getName()),
+                                       getDs().createUpdateOperations(ContainsPic.class)
+                                              .set("pic", pic),
+                                       new UpdateOptions())
+                          .getUpdatedCount(),
+                   is(1));
 
         //test reading the object.
         final ContainsPic cp2 = getDs().find(ContainsPic.class).get();
@@ -841,8 +857,10 @@ public class TestUpdateOps extends TestBase {
         assertThat(cp2.getPic().getName(), is(notNullValue()));
         assertThat(pic.getName(), is(cp2.getPic().getName()));
 
-        getDs().updateFirst(getDs().find(ContainsPic.class).filter("name", cp.getName()),
-                            getDs().createUpdateOperations(ContainsPic.class).set("pic", picKey));
+        getDs().update(getDs().find(ContainsPic.class).filter("name", cp.getName()),
+                       getDs().createUpdateOperations(ContainsPic.class)
+                              .set("pic", picKey),
+                       new UpdateOptions());
 
         //test reading the object.
         final ContainsPic cp3 = getDs().find(ContainsPic.class).get();
@@ -859,8 +877,9 @@ public class TestUpdateOps extends TestBase {
         cInt.val = 21;
         getDs().save(cInt);
 
-        final UpdateResults res = getDs().updateFirst(getDs().find(ContainsInt.class),
-                                                      getDs().createUpdateOperations(ContainsInt.class).inc("val", 1.1D));
+        final UpdateResults res = getDs().update(getDs().find(ContainsInt.class),
+                                                 getDs().createUpdateOperations(ContainsInt.class).inc("val", 1.1D),
+                                                 new UpdateOptions());
         assertUpdated(res, 1);
 
         assertThat(getDs().find(ContainsInt.class).get().val, is(22));
@@ -869,21 +888,23 @@ public class TestUpdateOps extends TestBase {
     @Test(expected = ValidationException.class)
     public void testValidationBadFieldName() throws Exception {
         getDs().update(getDs().find(Circle.class).field("radius").equal(0),
-                       getDs().createUpdateOperations(Circle.class).inc("r", 1D),
-                       true, WriteConcern.ACKNOWLEDGED);
+                       getDs().createUpdateOperations(Circle.class).inc("r", 1D));
     }
 
     @Test
     public void isolated() {
         UpdateOperations<Circle> updates = getDs().createUpdateOperations(Circle.class)
-                                                 .inc("radius", 1D);
+                                                  .inc("radius", 1D);
         assertFalse(updates.isIsolated());
         updates.isolated();
         assertTrue(updates.isIsolated());
 
-        getDs().update(getDs().find(Circle.class).field("radius").equal(0),
+        getDs().update(getDs().find(Circle.class)
+                              .field("radius").equal(0),
                        updates,
-                       true, WriteConcern.ACKNOWLEDGED);
+                       new UpdateOptions()
+                           .upsert(true)
+                           .writeConcern(WriteConcern.ACKNOWLEDGED));
     }
 
     private void assertInserted(final UpdateResults res) {

--- a/morphia/src/test/java/org/mongodb/morphia/TestVersionAnnotation.java
+++ b/morphia/src/test/java/org/mongodb/morphia/TestVersionAnnotation.java
@@ -135,6 +135,7 @@ public class TestVersionAnnotation extends TestBase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testUpdateFirst() {
         final Datastore datastore = getDs();
 
@@ -174,7 +175,7 @@ public class TestVersionAnnotation extends TestBase {
         query.field("_id").equal(version1.getId());
         UpdateOperations<Versioned> up = getDs().createUpdateOperations(Versioned.class).inc("count");
 
-        getDs().updateFirst(query, up, true);
+        getDs().update(query, up, new UpdateOptions().upsert(true));
 
         final Versioned version2 = getDs().get(Versioned.class, version1.getId());
 
@@ -241,7 +242,7 @@ public class TestVersionAnnotation extends TestBase {
         query.filter("name", "Value 1");
         UpdateOperations<Versioned> ops = datastore.createUpdateOperations(Versioned.class);
         ops.set("name", "Value 3");
-        datastore.update(query, ops, true);
+        datastore.update(query, ops, new UpdateOptions().upsert(true));
 
         entity = datastore.find(Versioned.class).get();
         Assert.assertEquals("Value 3", entity.getName());


### PR DESCRIPTION
This commit mostly just makes the `update` methods consistent with the changes to the saves and deletes.  The biggest arguable change is the deprecation of the `updateFirst` variants.  Looking at the API it seems there was some attempt at symmetry, over the years, to make `updateFirst` versions of the `update` methods.  This hasn't quite happened, however, and with easy access to `UpdateOptions` now, having `updateFirst` as separate methods makes less sense.  In the spirit of simplifying and streamlining the API, I've elected to deprecate the `updateFirst` methods in favor of the `update` methods.

The tests have been updated to use the correct methods and some new tests introduced to make sure the old methods still get tested.  I did a little bit of clean up to help isolate where we've been over testing and reduced that redundancy.