### PR TITLE
Added timezone to test so that it no longer fails when run in CET.

### DIFF
--- a/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
+++ b/morphia/src/test/java/org/mongodb/morphia/aggregation/AggregationTest.java
@@ -148,7 +148,7 @@ public class AggregationTest extends TestBase {
     @Test
     public void testDateToString() throws ParseException {
         checkMinServerVersion(3.0);
-        Date joined = new SimpleDateFormat("yyyy-MM-dd").parse("2016-05-01");
+        Date joined = new SimpleDateFormat("yyyy-MM-dd z").parse("2016-05-01 UTC");
         getDs().save(new User("John Doe", joined));
         AggregationPipeline pipeline = getDs()
             .createAggregation(User.class)


### PR DESCRIPTION
This test always fails for me locally, it shows an actual date of yesterday rather than today.  Adding a specific timezone appears to have fixed it for me.